### PR TITLE
Fix CMakeLists.txt: remove non-existent versioned headers and simplify targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,18 +22,6 @@ target_sources(
             FILES ${YK_POLYFILL_HEADERS}
 )
 
-# C++ versions for tests
-list(
-    APPEND
-    YK_POLYFILL_CXX_VERSIONS
-    11
-    14
-    17
-    20
-    23
-    26
-)
-
 # alias
 add_library(yk::polyfill ALIAS yk_polyfill)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,7 @@ target_sources(
             FILES ${YK_POLYFILL_COMMON_HEADERS}
 )
 
-# versioned headers
+# C++ versions for tests
 list(
     APPEND
     YK_POLYFILL_CXX_VERSIONS
@@ -37,31 +37,13 @@ list(
     26
 )
 
-foreach(cxx_version ${YK_POLYFILL_CXX_VERSIONS})
-    set(target_name yk_polyfill_cxx${cxx_version})
-    add_library(${target_name} INTERFACE)
-    set_target_properties(
-        ${target_name}
-        PROPERTIES EXPORT_NAME polyfill::cxx${cxx_version} CXX_EXTENSIONS OFF
-    )
-    target_compile_features(${target_name} INTERFACE cxx_std_${cxx_version})
-    target_link_libraries(${target_name} INTERFACE yk_polyfill_common)
-    list(APPEND YK_POLYFILL_VERSIONED_TARGETS ${target_name})
-endforeach()
-
 # aggregate
 add_library(yk_polyfill INTERFACE)
 set_target_properties(yk_polyfill PROPERTIES EXPORT_NAME polyfill)
-target_link_libraries(yk_polyfill INTERFACE ${YK_POLYFILL_VERSIONED_TARGETS})
+target_link_libraries(yk_polyfill INTERFACE yk_polyfill_common)
 
 # alias
 add_library(yk::polyfill::common ALIAS yk_polyfill_common)
-foreach(cxx_version ${YK_POLYFILL_CXX_VERSIONS})
-    add_library(
-        yk::polyfill::cxx${cxx_version}
-        ALIAS yk_polyfill_cxx${cxx_version}
-    )
-endforeach()
 add_library(yk::polyfill ALIAS yk_polyfill)
 
 # test
@@ -83,12 +65,6 @@ install(
     FILE_SET yk_polyfill_common_headers_set
 )
 
-foreach(cxx_version ${YK_POLYFILL_CXX_VERSIONS})
-    install(
-        TARGETS yk_polyfill_cxx${cxx_version}
-        EXPORT yk-polyfill-export
-    )
-endforeach()
 install(TARGETS yk_polyfill EXPORT yk-polyfill-export)
 
 install(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,23 +6,20 @@ set(YK_POLYFILL_PREFIX ${CMAKE_CURRENT_SOURCE_DIR}/include/yk/polyfill)
 
 include(GNUInstallDirs)
 
-# common headers
-add_library(yk_polyfill_common INTERFACE)
-set_target_properties(
-    yk_polyfill_common
-    PROPERTIES EXPORT_NAME polyfill::common
-)
+# library
+add_library(yk_polyfill INTERFACE)
+set_target_properties(yk_polyfill PROPERTIES EXPORT_NAME polyfill)
 if(MSVC)
-    target_compile_options(yk_polyfill_common INTERFACE /Zc:__cplusplus)
+    target_compile_options(yk_polyfill INTERFACE /Zc:__cplusplus)
 endif()
-file(GLOB_RECURSE YK_POLYFILL_COMMON_HEADERS ${YK_POLYFILL_PREFIX}/*.hpp)
+file(GLOB_RECURSE YK_POLYFILL_HEADERS ${YK_POLYFILL_PREFIX}/*.hpp)
 target_sources(
-    yk_polyfill_common
+    yk_polyfill
     INTERFACE
-        FILE_SET yk_polyfill_common_headers_set
+        FILE_SET yk_polyfill_headers_set
             TYPE HEADERS
             BASE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/include
-            FILES ${YK_POLYFILL_COMMON_HEADERS}
+            FILES ${YK_POLYFILL_HEADERS}
 )
 
 # C++ versions for tests
@@ -37,13 +34,7 @@ list(
     26
 )
 
-# aggregate
-add_library(yk_polyfill INTERFACE)
-set_target_properties(yk_polyfill PROPERTIES EXPORT_NAME polyfill)
-target_link_libraries(yk_polyfill INTERFACE yk_polyfill_common)
-
 # alias
-add_library(yk::polyfill::common ALIAS yk_polyfill_common)
 add_library(yk::polyfill ALIAS yk_polyfill)
 
 # test
@@ -60,12 +51,10 @@ endif()
 
 # install
 install(
-    TARGETS yk_polyfill_common
+    TARGETS yk_polyfill
     EXPORT yk-polyfill-export
-    FILE_SET yk_polyfill_common_headers_set
+    FILE_SET yk_polyfill_headers_set
 )
-
-install(TARGETS yk_polyfill EXPORT yk-polyfill-export)
 
 install(
     EXPORT yk-polyfill-export

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@ set_target_properties(
 if(MSVC)
     target_compile_options(yk_polyfill_common INTERFACE /Zc:__cplusplus)
 endif()
-file(GLOB YK_POLYFILL_COMMON_HEADERS ${YK_POLYFILL_PREFIX}/*.hpp)
+file(GLOB_RECURSE YK_POLYFILL_COMMON_HEADERS ${YK_POLYFILL_PREFIX}/*.hpp)
 target_sources(
     yk_polyfill_common
     INTERFACE
@@ -39,25 +39,12 @@ list(
 
 foreach(cxx_version ${YK_POLYFILL_CXX_VERSIONS})
     set(target_name yk_polyfill_cxx${cxx_version})
-    set(subfolder cxx${cxx_version})
     add_library(${target_name} INTERFACE)
     set_target_properties(
         ${target_name}
         PROPERTIES EXPORT_NAME polyfill::cxx${cxx_version} CXX_EXTENSIONS OFF
     )
     target_compile_features(${target_name} INTERFACE cxx_std_${cxx_version})
-    file(
-        GLOB_RECURSE YK_POLYFILL_CXX${cxx_version}_HEADERS
-        ${YK_POLYFILL_PREFIX}/${subfolder}/*.hpp
-    )
-    target_sources(
-        ${target_name}
-        INTERFACE
-            FILE_SET yk_polyfill_cxx${cxx_version}_headers_set
-                TYPE HEADERS
-                BASE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/include
-                FILES ${YK_POLYFILL_CXX${cxx_version}_HEADERS}
-    )
     target_link_libraries(${target_name} INTERFACE yk_polyfill_common)
     list(APPEND YK_POLYFILL_VERSIONED_TARGETS ${target_name})
 endforeach()
@@ -97,12 +84,9 @@ install(
 )
 
 foreach(cxx_version ${YK_POLYFILL_CXX_VERSIONS})
-    set(target_name yk_polyfill_cxx${cxx_version})
-    set(subfolder yk/polyfill/cxx${cxx_version})
     install(
-        TARGETS ${target_name}
+        TARGETS yk_polyfill_cxx${cxx_version}
         EXPORT yk-polyfill-export
-        FILE_SET yk_polyfill_cxx${cxx_version}_headers_set
     )
 endforeach()
 install(TARGETS yk_polyfill EXPORT yk-polyfill-export)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -8,6 +8,8 @@ else()
     set(YK_POLYFILL_CXX_STANDARD 11)
 endif()
 
+set(YK_POLYFILL_CXX_VERSIONS 11 14 17 20 23 26)
+
 foreach(required_cxx_version ${YK_POLYFILL_CXX_VERSIONS})
     if(${required_cxx_version} GREATER ${YK_POLYFILL_CXX_STANDARD})
         continue()

--- a/test/cxx11/CMakeLists.txt
+++ b/test/cxx11/CMakeLists.txt
@@ -38,9 +38,10 @@ target_compile_definitions(
     PRIVATE YK_POLYFILL_CATCH2_MAJOR_VERSION=${YK_POLYFILL_CATCH2_MAJOR_VERSION}
 )
 
+target_compile_features(yk_polyfill_cxx11_test PRIVATE cxx_std_11)
 target_link_libraries(
     yk_polyfill_cxx11_test
-    PRIVATE yk::polyfill::cxx11 Catch2::Catch2WithMain
+    PRIVATE yk::polyfill Catch2::Catch2WithMain
 )
 
 add_test(NAME yk_polyfill_cxx11_test COMMAND yk_polyfill_cxx11_test)

--- a/test/cxx14/CMakeLists.txt
+++ b/test/cxx14/CMakeLists.txt
@@ -16,9 +16,10 @@ target_compile_definitions(
     PRIVATE YK_POLYFILL_CATCH2_MAJOR_VERSION=${YK_POLYFILL_CATCH2_MAJOR_VERSION}
 )
 
+target_compile_features(yk_polyfill_cxx14_test PRIVATE cxx_std_14)
 target_link_libraries(
     yk_polyfill_cxx14_test
-    PRIVATE yk::polyfill::cxx14 Catch2::Catch2WithMain
+    PRIVATE yk::polyfill Catch2::Catch2WithMain
 )
 
 add_test(NAME yk_polyfill_cxx14_test COMMAND yk_polyfill_cxx14_test)

--- a/test/cxx17/CMakeLists.txt
+++ b/test/cxx17/CMakeLists.txt
@@ -15,9 +15,10 @@ target_compile_definitions(
     PRIVATE YK_POLYFILL_CATCH2_MAJOR_VERSION=${YK_POLYFILL_CATCH2_MAJOR_VERSION}
 )
 
+target_compile_features(yk_polyfill_cxx17_test PRIVATE cxx_std_17)
 target_link_libraries(
     yk_polyfill_cxx17_test
-    PRIVATE yk::polyfill::cxx17 Catch2::Catch2WithMain
+    PRIVATE yk::polyfill Catch2::Catch2WithMain
 )
 
 add_test(NAME yk_polyfill_cxx17_test COMMAND yk_polyfill_cxx17_test)

--- a/test/cxx20/CMakeLists.txt
+++ b/test/cxx20/CMakeLists.txt
@@ -9,9 +9,10 @@ target_compile_definitions(
     PRIVATE YK_POLYFILL_CATCH2_MAJOR_VERSION=${YK_POLYFILL_CATCH2_MAJOR_VERSION}
 )
 
+target_compile_features(yk_polyfill_cxx20_test PRIVATE cxx_std_20)
 target_link_libraries(
     yk_polyfill_cxx20_test
-    PRIVATE yk::polyfill::cxx20 Catch2::Catch2WithMain
+    PRIVATE yk::polyfill Catch2::Catch2WithMain
 )
 
 add_test(NAME yk_polyfill_cxx20_test COMMAND yk_polyfill_cxx20_test)

--- a/test/cxx23/CMakeLists.txt
+++ b/test/cxx23/CMakeLists.txt
@@ -9,9 +9,10 @@ target_compile_definitions(
     PRIVATE YK_POLYFILL_CATCH2_MAJOR_VERSION=${YK_POLYFILL_CATCH2_MAJOR_VERSION}
 )
 
+target_compile_features(yk_polyfill_cxx23_test PRIVATE cxx_std_23)
 target_link_libraries(
     yk_polyfill_cxx23_test
-    PRIVATE yk::polyfill::cxx23 Catch2::Catch2WithMain
+    PRIVATE yk::polyfill Catch2::Catch2WithMain
 )
 
 add_test(NAME yk_polyfill_cxx23_test COMMAND yk_polyfill_cxx23_test)


### PR DESCRIPTION
## Summary

- **Fixed headers glob**: Changed `GLOB` to `GLOB_RECURSE` so headers in `bits/` and `extension/` subdirectories are properly included
- **Removed versioned targets**: The per-version library targets (`yk_polyfill_cxx11`, `cxx14`, etc.) referenced non-existent `cxx*/` subdirectories and only served to set `cxx_std_N`. Compile features are now set directly in each test target via `target_compile_features()`
- **Removed `yk_polyfill_common`**: With versioned targets gone, the common/aggregate split was unnecessary. Consolidated into a single `yk_polyfill` target

## Test plan

- [x] Verify CMake configuration succeeds without warnings
- [x] Verify tests still build and link correctly with `yk::polyfill` + per-test `target_compile_features()`
- [x] Verify `cmake --install` installs all headers correctly

https://claude.ai/code/session_01MwutqPiFaZA5Y19wA3NVT6