### PR TITLE
Add `expected`

### DIFF
--- a/include/yk/polyfill/bits/expected_void.ipp
+++ b/include/yk/polyfill/bits/expected_void.ipp
@@ -1,0 +1,356 @@
+#ifndef YK_POLYFILL_INCLUDE_EXPECTED
+#warning "Do not include this file directly."
+#else
+
+// Included once per cv-qualification of void with YK_POLYFILL_EXPECTED_VOID_CV set to that
+// qualification; the standard's single constrained partial specialization (requires is_void_v<T>)
+// is not expressible before C++20.
+
+namespace yk {
+
+namespace polyfill {
+
+template<class E>
+class expected<void YK_POLYFILL_EXPECTED_VOID_CV, E> : private detail::cond_trivial_smf<detail::expected_void_storage_base<E>, E> {
+private:
+  using base_type = detail::cond_trivial_smf<detail::expected_void_storage_base<E>, E>;
+
+  static_assert(std::is_object<E>::value && !std::is_array<E>::value && !std::is_const<E>::value && !std::is_volatile<E>::value,
+                "E must be a valid unexpected type");
+
+public:
+  using value_type = void YK_POLYFILL_EXPECTED_VOID_CV;
+  using error_type = E;
+  using unexpected_type = unexpected<E>;
+
+  template<class U>
+  using rebind = expected<U, error_type>;
+
+  constexpr expected() noexcept : base_type(in_place) {}
+
+  // copy/move constructors are implicit (provided by cond_trivial_smf base)
+
+  template<
+      class U, class G,
+      typename std::enable_if<std::is_void<U>::value && detail::expected_void_can_convert<U, E, G, G const&>::value && std::is_convertible<G const&, E>::value,
+                              std::nullptr_t>::type = nullptr>
+  YK_POLYFILL_CXX20_CONSTEXPR expected(expected<U, G> const& rhs) noexcept(std::is_nothrow_constructible<E, G const&>::value) : base_type()
+  {
+    if (!rhs.has_value()) {
+      this->construct_error(rhs.error());
+    }
+  }
+
+  template<
+      class U, class G,
+      typename std::enable_if<std::is_void<U>::value && detail::expected_void_can_convert<U, E, G, G const&>::value && !std::is_convertible<G const&, E>::value,
+                              std::nullptr_t>::type = nullptr>
+  YK_POLYFILL_CXX20_CONSTEXPR explicit expected(expected<U, G> const& rhs) noexcept(std::is_nothrow_constructible<E, G const&>::value) : base_type()
+  {
+    if (!rhs.has_value()) {
+      this->construct_error(rhs.error());
+    }
+  }
+
+  template<class U, class G,
+           typename std::enable_if<std::is_void<U>::value && detail::expected_void_can_convert<U, E, G, G>::value && std::is_convertible<G, E>::value,
+                                   std::nullptr_t>::type = nullptr>
+  YK_POLYFILL_CXX20_CONSTEXPR expected(expected<U, G>&& rhs) noexcept(std::is_nothrow_constructible<E, G>::value) : base_type()
+  {
+    if (!rhs.has_value()) {
+      this->construct_error(std::move(rhs).error());
+    }
+  }
+
+  template<class U, class G,
+           typename std::enable_if<std::is_void<U>::value && detail::expected_void_can_convert<U, E, G, G>::value && !std::is_convertible<G, E>::value,
+                                   std::nullptr_t>::type = nullptr>
+  YK_POLYFILL_CXX20_CONSTEXPR explicit expected(expected<U, G>&& rhs) noexcept(std::is_nothrow_constructible<E, G>::value) : base_type()
+  {
+    if (!rhs.has_value()) {
+      this->construct_error(std::move(rhs).error());
+    }
+  }
+
+  template<class G,
+           typename std::enable_if<std::is_constructible<E, G const&>::value && std::is_convertible<G const&, E>::value, std::nullptr_t>::type = nullptr>
+  constexpr expected(unexpected<G> const& e) noexcept(std::is_nothrow_constructible<E, G const&>::value) : base_type(unexpect, e.error())
+  {
+  }
+
+  template<class G,
+           typename std::enable_if<std::is_constructible<E, G const&>::value && !std::is_convertible<G const&, E>::value, std::nullptr_t>::type = nullptr>
+  constexpr explicit expected(unexpected<G> const& e) noexcept(std::is_nothrow_constructible<E, G const&>::value) : base_type(unexpect, e.error())
+  {
+  }
+
+  template<class G, typename std::enable_if<std::is_constructible<E, G>::value && std::is_convertible<G, E>::value, std::nullptr_t>::type = nullptr>
+  constexpr expected(unexpected<G>&& e) noexcept(std::is_nothrow_constructible<E, G>::value) : base_type(unexpect, std::move(e).error())
+  {
+  }
+
+  template<class G, typename std::enable_if<std::is_constructible<E, G>::value && !std::is_convertible<G, E>::value, std::nullptr_t>::type = nullptr>
+  constexpr explicit expected(unexpected<G>&& e) noexcept(std::is_nothrow_constructible<E, G>::value) : base_type(unexpect, std::move(e).error())
+  {
+  }
+
+  constexpr explicit expected(in_place_t) noexcept : base_type(in_place) {}
+
+  template<class... Args, typename std::enable_if<std::is_constructible<E, Args...>::value, std::nullptr_t>::type = nullptr>
+  constexpr explicit expected(unexpect_t, Args&&... args) noexcept(std::is_nothrow_constructible<E, Args...>::value)
+      : base_type(unexpect, std::forward<Args>(args)...)
+  {
+  }
+
+  template<class U, class... Args, typename std::enable_if<std::is_constructible<E, std::initializer_list<U>&, Args...>::value, std::nullptr_t>::type = nullptr>
+  constexpr explicit expected(unexpect_t, std::initializer_list<U> il, Args&&... args)
+      noexcept(std::is_nothrow_constructible<E, std::initializer_list<U>&, Args...>::value)
+      : base_type(unexpect, il, std::forward<Args>(args)...)
+  {
+  }
+
+  // assignment (copy/move assignment are implicit)
+
+  template<class G,
+           typename std::enable_if<std::is_constructible<E, G const&>::value && std::is_assignable<E&, G const&>::value, std::nullptr_t>::type = nullptr>
+  YK_POLYFILL_CXX20_CONSTEXPR expected& operator=(unexpected<G> const& e)
+  {
+    if (has_value()) {
+      this->construct_error(e.error());
+    } else {
+      this->get_error() = e.error();
+    }
+    return *this;
+  }
+
+  template<class G, typename std::enable_if<std::is_constructible<E, G>::value && std::is_assignable<E&, G>::value, std::nullptr_t>::type = nullptr>
+  YK_POLYFILL_CXX20_CONSTEXPR expected& operator=(unexpected<G>&& e)
+  {
+    if (has_value()) {
+      this->construct_error(std::move(e).error());
+    } else {
+      this->get_error() = std::move(e).error();
+    }
+    return *this;
+  }
+
+  YK_POLYFILL_CXX20_CONSTEXPR void emplace() noexcept { this->destroy(); }
+
+  // [expected.void.swap]
+  template<class E2 = E,
+           typename std::enable_if<is_swappable<E2>::value && std::is_move_constructible<E2>::value, std::nullptr_t>::type = nullptr>
+  YK_POLYFILL_CXX20_CONSTEXPR void swap(expected& rhs) noexcept(std::is_nothrow_move_constructible<E>::value && is_nothrow_swappable<E>::value)
+  {
+    if (rhs.has_value()) {
+      if (!has_value()) {
+        rhs.construct_error(std::move(this->get_error()));
+        this->destroy();
+      }
+    } else {
+      if (has_value()) {
+        this->construct_error(std::move(rhs.get_error()));
+        rhs.destroy();
+      } else {
+        using std::swap;
+        swap(this->get_error(), rhs.get_error());
+      }
+    }
+  }
+
+  // observers
+
+  YK_POLYFILL_NODISCARD constexpr explicit operator bool() const noexcept { return has_value(); }
+  YK_POLYFILL_NODISCARD constexpr bool has_value() const noexcept { return base_type::has_value(); }
+
+  YK_POLYFILL_CXX14_CONSTEXPR void operator*() const noexcept {}
+
+  YK_POLYFILL_CXX14_CONSTEXPR void value() const&
+  {
+    static_assert(std::is_copy_constructible<E>::value, "E must be copy constructible");
+    if (!has_value()) throw bad_expected_access<E>(this->get_error());
+  }
+  YK_POLYFILL_CXX14_CONSTEXPR void value() &&
+  {
+    static_assert(std::is_copy_constructible<E>::value && std::is_move_constructible<E>::value, "E must be copy and move constructible");
+    if (!has_value()) throw bad_expected_access<E>(std::move(this->get_error()));
+  }
+
+  YK_POLYFILL_NODISCARD constexpr E const& error() const& noexcept { return this->get_error(); }
+  YK_POLYFILL_NODISCARD YK_POLYFILL_CXX14_CONSTEXPR E& error() & noexcept { return this->get_error(); }
+  YK_POLYFILL_NODISCARD constexpr E const&& error() const&& noexcept { return std::move(*this).base_get_error(); }
+  YK_POLYFILL_NODISCARD YK_POLYFILL_CXX14_CONSTEXPR E&& error() && noexcept { return std::move(*this).base_get_error(); }
+
+  template<class G = E>
+  YK_POLYFILL_CXX14_CONSTEXPR E error_or(G&& e) const&
+  {
+    static_assert(std::is_copy_constructible<E>::value && std::is_convertible<G, E>::value, "E must be copy constructible and the argument convertible to E");
+    return has_value() ? static_cast<E>(std::forward<G>(e)) : this->get_error();
+  }
+
+  template<class G = E>
+  YK_POLYFILL_CXX14_CONSTEXPR E error_or(G&& e) &&
+  {
+    static_assert(std::is_move_constructible<E>::value && std::is_convertible<G, E>::value, "E must be move constructible and the argument convertible to E");
+    return has_value() ? static_cast<E>(std::forward<G>(e)) : std::move(this->get_error());
+  }
+
+  // monadic operations
+
+  template<class F, class E2 = E, typename std::enable_if<std::is_constructible<E2, E2&>::value, std::nullptr_t>::type = nullptr>
+  YK_POLYFILL_CXX14_CONSTEXPR auto and_then(F&& f) & -> typename remove_cvref<typename invoke_result<F>::type>::type
+  {
+    using U = typename remove_cvref<typename invoke_result<F>::type>::type;
+    static_assert(detail::is_expected<U>::value, "result of F must be a specialization of expected");
+    static_assert(std::is_same<typename U::error_type, E>::value, "F's expected result must have the same error_type");
+    if (has_value()) return polyfill::invoke(std::forward<F>(f));
+    return U(unexpect, this->get_error());
+  }
+
+  template<class F, class E2 = E, typename std::enable_if<std::is_constructible<E2, E2 const&>::value, std::nullptr_t>::type = nullptr>
+  YK_POLYFILL_CXX14_CONSTEXPR auto and_then(F&& f) const& -> typename remove_cvref<typename invoke_result<F>::type>::type
+  {
+    using U = typename remove_cvref<typename invoke_result<F>::type>::type;
+    static_assert(detail::is_expected<U>::value, "result of F must be a specialization of expected");
+    static_assert(std::is_same<typename U::error_type, E>::value, "F's expected result must have the same error_type");
+    if (has_value()) return polyfill::invoke(std::forward<F>(f));
+    return U(unexpect, this->get_error());
+  }
+
+  template<class F, class E2 = E, typename std::enable_if<std::is_constructible<E2, E2&&>::value, std::nullptr_t>::type = nullptr>
+  YK_POLYFILL_CXX14_CONSTEXPR auto and_then(F&& f) && -> typename remove_cvref<typename invoke_result<F>::type>::type
+  {
+    using U = typename remove_cvref<typename invoke_result<F>::type>::type;
+    static_assert(detail::is_expected<U>::value, "result of F must be a specialization of expected");
+    static_assert(std::is_same<typename U::error_type, E>::value, "F's expected result must have the same error_type");
+    if (has_value()) return polyfill::invoke(std::forward<F>(f));
+    return U(unexpect, std::move(this->get_error()));
+  }
+
+  template<class F, class E2 = E, typename std::enable_if<std::is_constructible<E2, E2 const&&>::value, std::nullptr_t>::type = nullptr>
+  YK_POLYFILL_CXX14_CONSTEXPR auto and_then(F&& f) const&& -> typename remove_cvref<typename invoke_result<F>::type>::type
+  {
+    using U = typename remove_cvref<typename invoke_result<F>::type>::type;
+    static_assert(detail::is_expected<U>::value, "result of F must be a specialization of expected");
+    static_assert(std::is_same<typename U::error_type, E>::value, "F's expected result must have the same error_type");
+    if (has_value()) return polyfill::invoke(std::forward<F>(f));
+    return U(unexpect, std::move(this->get_error()));
+  }
+
+  template<class F>
+  YK_POLYFILL_CXX14_CONSTEXPR auto or_else(F&& f) & -> typename remove_cvref<typename invoke_result<F, E&>::type>::type
+  {
+    using G = typename remove_cvref<typename invoke_result<F, E&>::type>::type;
+    static_assert(detail::is_expected<G>::value, "result of F must be a specialization of expected");
+    static_assert(std::is_same<typename G::value_type, void YK_POLYFILL_EXPECTED_VOID_CV>::value, "F's expected result must have the same value_type");
+    if (has_value()) return G();
+    return polyfill::invoke(std::forward<F>(f), this->get_error());
+  }
+
+  template<class F>
+  YK_POLYFILL_CXX14_CONSTEXPR auto or_else(F&& f) const& -> typename remove_cvref<typename invoke_result<F, E const&>::type>::type
+  {
+    using G = typename remove_cvref<typename invoke_result<F, E const&>::type>::type;
+    static_assert(detail::is_expected<G>::value, "result of F must be a specialization of expected");
+    static_assert(std::is_same<typename G::value_type, void YK_POLYFILL_EXPECTED_VOID_CV>::value, "F's expected result must have the same value_type");
+    if (has_value()) return G();
+    return polyfill::invoke(std::forward<F>(f), this->get_error());
+  }
+
+  template<class F>
+  YK_POLYFILL_CXX14_CONSTEXPR auto or_else(F&& f) && -> typename remove_cvref<typename invoke_result<F, E&&>::type>::type
+  {
+    using G = typename remove_cvref<typename invoke_result<F, E&&>::type>::type;
+    static_assert(detail::is_expected<G>::value, "result of F must be a specialization of expected");
+    static_assert(std::is_same<typename G::value_type, void YK_POLYFILL_EXPECTED_VOID_CV>::value, "F's expected result must have the same value_type");
+    if (has_value()) return G();
+    return polyfill::invoke(std::forward<F>(f), std::move(this->get_error()));
+  }
+
+  template<class F>
+  YK_POLYFILL_CXX14_CONSTEXPR auto or_else(F&& f) const&& -> typename remove_cvref<typename invoke_result<F, E const&&>::type>::type
+  {
+    using G = typename remove_cvref<typename invoke_result<F, E const&&>::type>::type;
+    static_assert(detail::is_expected<G>::value, "result of F must be a specialization of expected");
+    static_assert(std::is_same<typename G::value_type, void YK_POLYFILL_EXPECTED_VOID_CV>::value, "F's expected result must have the same value_type");
+    if (has_value()) return G();
+    return polyfill::invoke(std::forward<F>(f), std::move(this->get_error()));
+  }
+
+  template<class F, class E2 = E, typename std::enable_if<std::is_constructible<E2, E2&>::value, std::nullptr_t>::type = nullptr>
+  YK_POLYFILL_CXX14_CONSTEXPR auto transform(F&& f) & -> expected<typename std::remove_cv<typename invoke_result<F>::type>::type, E>
+  {
+    using U = typename std::remove_cv<typename invoke_result<F>::type>::type;
+    if (has_value()) return detail::expected_transform_make<expected<U, E>>(bool_constant<std::is_void<U>::value>{}, std::forward<F>(f));
+    return expected<U, E>(unexpect, this->get_error());
+  }
+
+  template<class F, class E2 = E, typename std::enable_if<std::is_constructible<E2, E2 const&>::value, std::nullptr_t>::type = nullptr>
+  YK_POLYFILL_CXX14_CONSTEXPR auto transform(F&& f) const& -> expected<typename std::remove_cv<typename invoke_result<F>::type>::type, E>
+  {
+    using U = typename std::remove_cv<typename invoke_result<F>::type>::type;
+    if (has_value()) return detail::expected_transform_make<expected<U, E>>(bool_constant<std::is_void<U>::value>{}, std::forward<F>(f));
+    return expected<U, E>(unexpect, this->get_error());
+  }
+
+  template<class F, class E2 = E, typename std::enable_if<std::is_constructible<E2, E2&&>::value, std::nullptr_t>::type = nullptr>
+  YK_POLYFILL_CXX14_CONSTEXPR auto transform(F&& f) && -> expected<typename std::remove_cv<typename invoke_result<F>::type>::type, E>
+  {
+    using U = typename std::remove_cv<typename invoke_result<F>::type>::type;
+    if (has_value()) return detail::expected_transform_make<expected<U, E>>(bool_constant<std::is_void<U>::value>{}, std::forward<F>(f));
+    return expected<U, E>(unexpect, std::move(this->get_error()));
+  }
+
+  template<class F, class E2 = E, typename std::enable_if<std::is_constructible<E2, E2 const&&>::value, std::nullptr_t>::type = nullptr>
+  YK_POLYFILL_CXX14_CONSTEXPR auto transform(F&& f) const&& -> expected<typename std::remove_cv<typename invoke_result<F>::type>::type, E>
+  {
+    using U = typename std::remove_cv<typename invoke_result<F>::type>::type;
+    if (has_value()) return detail::expected_transform_make<expected<U, E>>(bool_constant<std::is_void<U>::value>{}, std::forward<F>(f));
+    return expected<U, E>(unexpect, std::move(this->get_error()));
+  }
+
+  template<class F>
+  YK_POLYFILL_CXX14_CONSTEXPR auto transform_error(F&& f) &
+      -> expected<void YK_POLYFILL_EXPECTED_VOID_CV, typename std::remove_cv<typename invoke_result<F, E&>::type>::type>
+  {
+    using G = typename std::remove_cv<typename invoke_result<F, E&>::type>::type;
+    if (has_value()) return expected<void YK_POLYFILL_EXPECTED_VOID_CV, G>();
+    return expected<void YK_POLYFILL_EXPECTED_VOID_CV, G>(unexpect, polyfill::invoke(std::forward<F>(f), this->get_error()));
+  }
+
+  template<class F>
+  YK_POLYFILL_CXX14_CONSTEXPR auto transform_error(F&& f) const&
+      -> expected<void YK_POLYFILL_EXPECTED_VOID_CV, typename std::remove_cv<typename invoke_result<F, E const&>::type>::type>
+  {
+    using G = typename std::remove_cv<typename invoke_result<F, E const&>::type>::type;
+    if (has_value()) return expected<void YK_POLYFILL_EXPECTED_VOID_CV, G>();
+    return expected<void YK_POLYFILL_EXPECTED_VOID_CV, G>(unexpect, polyfill::invoke(std::forward<F>(f), this->get_error()));
+  }
+
+  template<class F>
+  YK_POLYFILL_CXX14_CONSTEXPR auto transform_error(F&& f) &&
+      -> expected<void YK_POLYFILL_EXPECTED_VOID_CV, typename std::remove_cv<typename invoke_result<F, E&&>::type>::type>
+  {
+    using G = typename std::remove_cv<typename invoke_result<F, E&&>::type>::type;
+    if (has_value()) return expected<void YK_POLYFILL_EXPECTED_VOID_CV, G>();
+    return expected<void YK_POLYFILL_EXPECTED_VOID_CV, G>(unexpect, polyfill::invoke(std::forward<F>(f), std::move(this->get_error())));
+  }
+
+  template<class F>
+  YK_POLYFILL_CXX14_CONSTEXPR auto transform_error(F&& f) const&&
+      -> expected<void YK_POLYFILL_EXPECTED_VOID_CV, typename std::remove_cv<typename invoke_result<F, E const&&>::type>::type>
+  {
+    using G = typename std::remove_cv<typename invoke_result<F, E const&&>::type>::type;
+    if (has_value()) return expected<void YK_POLYFILL_EXPECTED_VOID_CV, G>();
+    return expected<void YK_POLYFILL_EXPECTED_VOID_CV, G>(unexpect, polyfill::invoke(std::forward<F>(f), std::move(this->get_error())));
+  }
+
+private:
+  YK_POLYFILL_CXX14_CONSTEXPR E&& base_get_error() && noexcept { return static_cast<base_type&&>(*this).get_error(); }
+  constexpr E const&& base_get_error() const&& noexcept { return static_cast<base_type const&&>(*this).get_error(); }
+};
+
+}  // namespace polyfill
+
+}  // namespace yk
+
+#endif

--- a/include/yk/polyfill/expected.hpp
+++ b/include/yk/polyfill/expected.hpp
@@ -1,0 +1,1543 @@
+#ifndef YK_ZZ_POLYFILL_EXPECTED_HPP
+#define YK_ZZ_POLYFILL_EXPECTED_HPP
+
+#include <yk/polyfill/bits/cond_trivial_smf.hpp>
+#include <yk/polyfill/bits/core_traits.hpp>
+
+#include <yk/polyfill/extension/specialization_of.hpp>
+
+#include <yk/polyfill/bits/optional_common.hpp>  // detail::converts_from_any_cvref
+#include <yk/polyfill/functional.hpp>            // invoke, invoke_result, is_invocable
+#include <yk/polyfill/memory.hpp>                // construct_at
+#include <yk/polyfill/type_traits.hpp>           // is_swappable, is_nothrow_swappable
+#include <yk/polyfill/utility.hpp>               // in_place_t, in_place
+
+#include <yk/polyfill/config.hpp>
+
+#include <exception>
+#include <initializer_list>
+#include <memory>
+#include <type_traits>
+#include <utility>
+
+namespace yk {
+
+namespace polyfill {
+
+template<class E>
+class unexpected;
+
+template<class T, class E>
+class expected;
+
+// [expected.unexpect]
+struct unexpect_t {
+  explicit unexpect_t() = default;
+};
+
+YK_POLYFILL_INLINE constexpr unexpect_t unexpect{};
+
+// [expected.bad] bad_expected_access
+template<class E>
+class bad_expected_access;
+
+template<>
+class bad_expected_access<void> : public std::exception {
+protected:
+  bad_expected_access() noexcept = default;
+  bad_expected_access(bad_expected_access const&) = default;
+  bad_expected_access(bad_expected_access&&) = default;
+  bad_expected_access& operator=(bad_expected_access const&) = default;
+  bad_expected_access& operator=(bad_expected_access&&) = default;
+  ~bad_expected_access() override = default;
+
+public:
+  char const* what() const noexcept override { return "bad access to expected without expected value"; }
+};
+
+template<class E>
+class bad_expected_access : public bad_expected_access<void> {
+public:
+  explicit bad_expected_access(E e) : error_(std::move(e)) {}
+
+  char const* what() const noexcept override { return "bad access to expected without expected value"; }
+
+  [[nodiscard]] E& error() & noexcept { return error_; }
+  [[nodiscard]] E const& error() const& noexcept { return error_; }
+  [[nodiscard]] E&& error() && noexcept { return std::move(error_); }
+  [[nodiscard]] E const&& error() const&& noexcept { return std::move(error_); }
+
+private:
+  E error_;
+};
+
+// [expected.un] unexpected
+template<class E>
+class unexpected {
+  static_assert(std::is_object<E>::value, "E must be an object type");
+  static_assert(!std::is_array<E>::value, "E must not be an array type");
+  static_assert(!std::is_const<E>::value && !std::is_volatile<E>::value, "E must not be cv-qualified");
+  static_assert(!extension::is_specialization_of<E, unexpected>::value, "E must not be a specialization of unexpected");
+
+public:
+  // copy/move constructors and assignment operators are implicit (a templated constructor
+  // does not suppress them); leaving them implicit keeps them constexpr where E permits
+  // without tripping C++11's rule that a constexpr member function is implicitly const.
+
+  template<class Err = E,
+           typename std::enable_if<!std::is_same<typename remove_cvref<Err>::type, unexpected>::value
+                                       && !std::is_same<typename remove_cvref<Err>::type, in_place_t>::value && std::is_constructible<E, Err>::value,
+                                   std::nullptr_t>::type = nullptr>
+  constexpr explicit unexpected(Err&& e) noexcept(std::is_nothrow_constructible<E, Err>::value) : error_(std::forward<Err>(e))
+  {
+  }
+
+  template<class... Args, typename std::enable_if<std::is_constructible<E, Args...>::value, std::nullptr_t>::type = nullptr>
+  constexpr explicit unexpected(in_place_t, Args&&... args) noexcept(std::is_nothrow_constructible<E, Args...>::value) : error_(std::forward<Args>(args)...)
+  {
+  }
+
+  template<class U, class... Args, typename std::enable_if<std::is_constructible<E, std::initializer_list<U>&, Args...>::value, std::nullptr_t>::type = nullptr>
+  constexpr explicit unexpected(in_place_t, std::initializer_list<U> il, Args&&... args)
+      noexcept(std::is_nothrow_constructible<E, std::initializer_list<U>&, Args...>::value)
+      : error_(il, std::forward<Args>(args)...)
+  {
+  }
+
+  [[nodiscard]] constexpr E const& error() const& noexcept { return error_; }
+  [[nodiscard]] YK_POLYFILL_CXX14_CONSTEXPR E& error() & noexcept { return error_; }
+  [[nodiscard]] constexpr E const&& error() const&& noexcept { return std::move(error_); }
+  [[nodiscard]] YK_POLYFILL_CXX14_CONSTEXPR E&& error() && noexcept { return std::move(error_); }
+
+  template<class E2 = E, typename std::enable_if<is_swappable<E2>::value, std::nullptr_t>::type = nullptr>
+  YK_POLYFILL_CXX14_CONSTEXPR void swap(unexpected& other) noexcept(is_nothrow_swappable<E>::value)
+  {
+    using std::swap;
+    swap(error_, other.error_);
+  }
+
+  template<class E2>
+  friend constexpr bool operator==(unexpected const& lhs, unexpected<E2> const& rhs) noexcept(noexcept(lhs.error() == rhs.error()))
+  {
+    return lhs.error() == rhs.error();
+  }
+
+#if __cplusplus < 202002L
+  template<class E2>
+  friend constexpr bool operator!=(unexpected const& lhs, unexpected<E2> const& rhs) noexcept(noexcept(lhs.error() != rhs.error()))
+  {
+    return lhs.error() != rhs.error();
+  }
+#endif
+
+  template<class E2 = E, typename std::enable_if<is_swappable<E2>::value, std::nullptr_t>::type = nullptr>
+  friend YK_POLYFILL_CXX14_CONSTEXPR void swap(unexpected& lhs, unexpected& rhs) noexcept(noexcept(lhs.swap(rhs)))
+  {
+    lhs.swap(rhs);
+  }
+
+private:
+  E error_;
+};
+
+#if __cpp_deduction_guides >= 201703L
+template<class E>
+unexpected(E) -> unexpected<E>;
+#endif
+
+namespace detail {
+
+template<class T>
+struct is_unexpected : false_type {};
+template<class E>
+struct is_unexpected<unexpected<E>> : true_type {};
+
+template<class T>
+struct is_expected : false_type {};
+template<class T, class E>
+struct is_expected<expected<T, E>> : true_type {};
+
+// is_constructible from every cvref of W (the is_convertible half of converts_from_any_cvref is
+// intentionally omitted: [expected.object.cons] checks only is_constructible on the unexpected side).
+template<class X, class W>
+struct constructs_from_any_cvref {
+  static constexpr bool value =
+      disjunction<std::is_constructible<X, W&>, std::is_constructible<X, W const&>, std::is_constructible<X, W&&>, std::is_constructible<X, W const&&>>::value;
+};
+
+// transient "no active member" marker for the storage's default-constructed state
+struct expected_uninit {};
+
+enum class expected_state { valueless, has_value, has_error };
+
+// [expected] reinit-expected strategy: how to construct the new arm without leaving the object
+// observably valueless, chosen by the constructibility of the new arm.
+enum class reinit_strategy {
+  destroy_then_construct,  // new arm is nothrow-constructible from args: destroy old, construct new in place
+  temporary_then_move,     // new arm is nothrow-move-constructible: build a temp, destroy old, move it in
+  backup_then_restore,     // neither: back up old arm, try constructing new, restore old on throw
+};
+
+//
+// expected<T, E> storage
+//
+
+template<class T, class E, bool = std::is_trivially_destructible<T>::value && std::is_trivially_destructible<E>::value>
+struct expected_destruct_base;
+
+template<class T, class E>
+struct expected_destruct_base<T, E, true> {  // both arms trivially destructible
+  union {
+    expected_uninit uninit_;
+    T val_;
+    E unex_;
+  };
+  expected_state state_;
+
+  constexpr expected_destruct_base() noexcept : uninit_(), state_(expected_state::valueless) {}
+
+  template<class... Args>
+  constexpr explicit expected_destruct_base(in_place_t, Args&&... args) noexcept(std::is_nothrow_constructible<T, Args...>::value)
+      : val_(std::forward<Args>(args)...), state_(expected_state::has_value)
+  {
+  }
+
+  template<class... Args>
+  constexpr explicit expected_destruct_base(unexpect_t, Args&&... args) noexcept(std::is_nothrow_constructible<E, Args...>::value)
+      : unex_(std::forward<Args>(args)...), state_(expected_state::has_error)
+  {
+  }
+
+  YK_POLYFILL_CXX14_CONSTEXPR void destroy() noexcept { state_ = expected_state::valueless; }
+};
+
+template<class T, class E>
+struct expected_destruct_base<T, E, false> {  // at least one arm NOT trivially destructible
+  union {
+    expected_uninit uninit_;
+    T val_;
+    E unex_;
+  };
+  expected_state state_;
+
+  constexpr expected_destruct_base() noexcept : uninit_(), state_(expected_state::valueless) {}
+
+  template<class... Args>
+  constexpr explicit expected_destruct_base(in_place_t, Args&&... args) noexcept(std::is_nothrow_constructible<T, Args...>::value)
+      : val_(std::forward<Args>(args)...), state_(expected_state::has_value)
+  {
+  }
+
+  template<class... Args>
+  constexpr explicit expected_destruct_base(unexpect_t, Args&&... args) noexcept(std::is_nothrow_constructible<E, Args...>::value)
+      : unex_(std::forward<Args>(args)...), state_(expected_state::has_error)
+  {
+  }
+
+  YK_POLYFILL_CXX20_CONSTEXPR ~expected_destruct_base() noexcept { destroy(); }
+
+  YK_POLYFILL_CXX20_CONSTEXPR void destroy() noexcept
+  {
+    if (state_ == expected_state::has_value) {
+      val_.~T();
+    } else if (state_ == expected_state::has_error) {
+      unex_.~E();
+    }
+    state_ = expected_state::valueless;
+  }
+};
+
+template<class T, class E>
+struct expected_storage_base;
+
+// [expected] reinit-expected, dispatched on reinit_strategy: construct *newp (the arm switched to)
+// from args..., destroying *oldp, leaving self.state_ consistent and never observably valueless.
+template<reinit_strategy S>
+struct reinit_expected_impl;
+
+template<>
+struct reinit_expected_impl<reinit_strategy::destroy_then_construct> {
+  template<class T, class E, class New, class Old, class... Args>
+  static YK_POLYFILL_CXX20_CONSTEXPR void apply(expected_storage_base<T, E>& self, New* newp, Old* oldp, expected_state new_state, expected_state,
+                                                Args&&... args) noexcept
+  {
+    oldp->~Old();
+    self.state_ = expected_state::valueless;
+    polyfill::construct_at(newp, std::forward<Args>(args)...);
+    self.state_ = new_state;
+  }
+};
+
+template<>
+struct reinit_expected_impl<reinit_strategy::temporary_then_move> {
+  template<class T, class E, class New, class Old, class... Args>
+  static YK_POLYFILL_CXX20_CONSTEXPR void apply(expected_storage_base<T, E>& self, New* newp, Old* oldp, expected_state new_state, expected_state,
+                                                Args&&... args)
+  {
+    New tmp(std::forward<Args>(args)...);
+    oldp->~Old();
+    self.state_ = expected_state::valueless;
+    polyfill::construct_at(newp, std::move(tmp));
+    self.state_ = new_state;
+  }
+};
+
+template<>
+struct reinit_expected_impl<reinit_strategy::backup_then_restore> {
+  template<class T, class E, class New, class Old, class... Args>
+  static YK_POLYFILL_CXX20_CONSTEXPR void apply(expected_storage_base<T, E>& self, New* newp, Old* oldp, expected_state new_state, expected_state old_state,
+                                                Args&&... args)
+  {
+    Old tmp(std::move(*oldp));
+    oldp->~Old();
+    self.state_ = expected_state::valueless;
+    try {
+      polyfill::construct_at(newp, std::forward<Args>(args)...);
+      self.state_ = new_state;
+    } catch (...) {
+      polyfill::construct_at(oldp, std::move(tmp));
+      self.state_ = old_state;
+      throw;
+    }
+  }
+};
+
+template<class T, class E>
+struct expected_storage_base : expected_destruct_base<T, E> {
+  using base = expected_destruct_base<T, E>;
+  using base::base;
+
+  [[nodiscard]] constexpr bool has_value() const noexcept { return base::state_ == expected_state::has_value; }
+
+  [[nodiscard]] YK_POLYFILL_CXX14_CONSTEXPR T& get_value() & noexcept { return base::val_; }
+  [[nodiscard]] constexpr T const& get_value() const& noexcept { return base::val_; }
+  [[nodiscard]] YK_POLYFILL_CXX14_CONSTEXPR T&& get_value() && noexcept { return std::move(base::val_); }
+  [[nodiscard]] constexpr T const&& get_value() const&& noexcept { return std::move(base::val_); }
+
+  [[nodiscard]] YK_POLYFILL_CXX14_CONSTEXPR E& get_error() & noexcept { return base::unex_; }
+  [[nodiscard]] constexpr E const& get_error() const& noexcept { return base::unex_; }
+  [[nodiscard]] YK_POLYFILL_CXX14_CONSTEXPR E&& get_error() && noexcept { return std::move(base::unex_); }
+  [[nodiscard]] constexpr E const&& get_error() const&& noexcept { return std::move(base::unex_); }
+
+  template<class... Args>
+  YK_POLYFILL_CXX20_CONSTEXPR void construct_value(Args&&... args) noexcept(std::is_nothrow_constructible<T, Args...>::value)
+  {
+    polyfill::construct_at(std::addressof(base::val_), std::forward<Args>(args)...);
+    base::state_ = expected_state::has_value;
+  }
+
+  template<class... Args>
+  YK_POLYFILL_CXX20_CONSTEXPR void construct_error(Args&&... args) noexcept(std::is_nothrow_constructible<E, Args...>::value)
+  {
+    polyfill::construct_at(std::addressof(base::unex_), std::forward<Args>(args)...);
+    base::state_ = expected_state::has_error;
+  }
+
+  // [expected] reinit-expected: switch the active arm, never leaving the object valueless.
+  // Precondition of reinit_to_value: state_ == has_error; of reinit_to_error: state_ == has_value.
+  template<class... Args>
+  YK_POLYFILL_CXX20_CONSTEXPR void reinit_to_value(Args&&... args)
+  {
+    reinit_expected(std::addressof(base::val_), std::addressof(base::unex_), expected_state::has_value, expected_state::has_error, std::forward<Args>(args)...);
+  }
+
+  template<class... Args>
+  YK_POLYFILL_CXX20_CONSTEXPR void reinit_to_error(Args&&... args)
+  {
+    reinit_expected(std::addressof(base::unex_), std::addressof(base::val_), expected_state::has_error, expected_state::has_value, std::forward<Args>(args)...);
+  }
+
+  // cond_trivial_smf hooks
+
+  YK_POLYFILL_CXX20_CONSTEXPR void _copy_construct(expected_storage_base const& other) { construct_from(other); }
+
+  YK_POLYFILL_CXX20_CONSTEXPR void _move_construct(expected_storage_base&& other)
+      noexcept(std::is_nothrow_move_constructible<T>::value && std::is_nothrow_move_constructible<E>::value)
+  {
+    construct_from(std::move(other));
+  }
+
+  YK_POLYFILL_CXX20_CONSTEXPR void _copy_assign(expected_storage_base const& other) { assign_from(other); }
+
+  YK_POLYFILL_CXX20_CONSTEXPR void _move_assign(expected_storage_base&& other)
+      noexcept(std::is_nothrow_move_constructible<T>::value && std::is_nothrow_move_assignable<T>::value && std::is_nothrow_move_constructible<E>::value
+               && std::is_nothrow_move_assignable<E>::value)
+  {
+    assign_from(std::move(other));
+  }
+
+private:
+  // Construct the active arm from other, preserving its value category (copy vs move) via Other&&.
+  template<class Other>
+  YK_POLYFILL_CXX20_CONSTEXPR void construct_from(Other&& other)
+  {
+    if (other.has_value()) {
+      construct_value(std::forward<Other>(other).val_);
+    } else {
+      construct_error(std::forward<Other>(other).unex_);
+    }
+  }
+
+  // Assign both arms from other, preserving its value category (copy vs move) via Other&&.
+  template<class Other>
+  YK_POLYFILL_CXX20_CONSTEXPR void assign_from(Other&& other)
+  {
+    if (has_value() && other.has_value()) {
+      base::val_ = std::forward<Other>(other).val_;
+    } else if (!has_value() && !other.has_value()) {
+      base::unex_ = std::forward<Other>(other).unex_;
+    } else if (has_value() && !other.has_value()) {
+      reinit_to_error(std::forward<Other>(other).unex_);
+    } else {
+      reinit_to_value(std::forward<Other>(other).val_);
+    }
+  }
+
+  // Construct *newp (the arm switched to) from args..., destroying *oldp; on throw, leave *oldp intact.
+  template<class New, class Old, class... Args>
+  YK_POLYFILL_CXX20_CONSTEXPR void reinit_expected(New* newp, Old* oldp, expected_state new_state, expected_state old_state, Args&&... args)
+  {
+    constexpr reinit_strategy strategy = std::is_nothrow_constructible<New, Args...>::value ? reinit_strategy::destroy_then_construct
+                                         : std::is_nothrow_move_constructible<New>::value   ? reinit_strategy::temporary_then_move
+                                                                                            : reinit_strategy::backup_then_restore;
+    reinit_expected_impl<strategy>::apply(*this, newp, oldp, new_state, old_state, std::forward<Args>(args)...);
+  }
+};
+
+//
+// expected<void, E> storage
+//
+
+template<class E, bool = std::is_trivially_destructible<E>::value>
+struct expected_void_destruct_base;
+
+template<class E>
+struct expected_void_destruct_base<E, true> {  // E trivially destructible
+  union {
+    expected_uninit uninit_;
+    E unex_;
+  };
+  bool has_val_;
+
+  constexpr expected_void_destruct_base() noexcept : uninit_(), has_val_(true) {}
+
+  constexpr explicit expected_void_destruct_base(in_place_t) noexcept : uninit_(), has_val_(true) {}
+
+  template<class... Args>
+  constexpr explicit expected_void_destruct_base(unexpect_t, Args&&... args) noexcept(std::is_nothrow_constructible<E, Args...>::value)
+      : unex_(std::forward<Args>(args)...), has_val_(false)
+  {
+  }
+
+  YK_POLYFILL_CXX14_CONSTEXPR void destroy() noexcept { has_val_ = true; }
+};
+
+template<class E>
+struct expected_void_destruct_base<E, false> {  // E NOT trivially destructible
+  union {
+    expected_uninit uninit_;
+    E unex_;
+  };
+  bool has_val_;
+
+  constexpr expected_void_destruct_base() noexcept : uninit_(), has_val_(true) {}
+
+  constexpr explicit expected_void_destruct_base(in_place_t) noexcept : uninit_(), has_val_(true) {}
+
+  template<class... Args>
+  constexpr explicit expected_void_destruct_base(unexpect_t, Args&&... args) noexcept(std::is_nothrow_constructible<E, Args...>::value)
+      : unex_(std::forward<Args>(args)...), has_val_(false)
+  {
+  }
+
+  YK_POLYFILL_CXX20_CONSTEXPR ~expected_void_destruct_base() noexcept { destroy(); }
+
+  YK_POLYFILL_CXX20_CONSTEXPR void destroy() noexcept
+  {
+    if (!has_val_) {
+      unex_.~E();
+      has_val_ = true;
+    }
+  }
+};
+
+template<class E>
+struct expected_void_storage_base : expected_void_destruct_base<E> {
+  using base = expected_void_destruct_base<E>;
+  using base::base;
+
+  [[nodiscard]] constexpr bool has_value() const noexcept { return base::has_val_; }
+
+  [[nodiscard]] YK_POLYFILL_CXX14_CONSTEXPR E& get_error() & noexcept { return base::unex_; }
+  [[nodiscard]] constexpr E const& get_error() const& noexcept { return base::unex_; }
+  [[nodiscard]] YK_POLYFILL_CXX14_CONSTEXPR E&& get_error() && noexcept { return std::move(base::unex_); }
+  [[nodiscard]] constexpr E const&& get_error() const&& noexcept { return std::move(base::unex_); }
+
+  YK_POLYFILL_CXX20_CONSTEXPR void construct_valueless_value() noexcept { base::has_val_ = true; }
+
+  template<class... Args>
+  YK_POLYFILL_CXX20_CONSTEXPR void construct_error(Args&&... args) noexcept(std::is_nothrow_constructible<E, Args...>::value)
+  {
+    polyfill::construct_at(std::addressof(base::unex_), std::forward<Args>(args)...);
+    base::has_val_ = false;
+  }
+
+  YK_POLYFILL_CXX20_CONSTEXPR void _copy_construct(expected_void_storage_base const& other) { construct_from(other); }
+
+  YK_POLYFILL_CXX20_CONSTEXPR void _move_construct(expected_void_storage_base&& other) noexcept(std::is_nothrow_move_constructible<E>::value)
+  {
+    construct_from(std::move(other));
+  }
+
+  YK_POLYFILL_CXX20_CONSTEXPR void _copy_assign(expected_void_storage_base const& other) { assign_from(other); }
+
+  YK_POLYFILL_CXX20_CONSTEXPR void _move_assign(expected_void_storage_base&& other)
+      noexcept(std::is_nothrow_move_constructible<E>::value && std::is_nothrow_move_assignable<E>::value)
+  {
+    assign_from(std::move(other));
+  }
+
+private:
+  // Construct the error arm from other when it holds an error; a valued other leaves this default (valued).
+  template<class Other>
+  YK_POLYFILL_CXX20_CONSTEXPR void construct_from(Other&& other)
+  {
+    if (!other.has_value()) {
+      construct_error(std::forward<Other>(other).unex_);
+    }
+  }
+
+  // Assign from other, preserving its value category (copy vs move) via Other&&.
+  template<class Other>
+  YK_POLYFILL_CXX20_CONSTEXPR void assign_from(Other&& other)
+  {
+    if (!has_value() && !other.has_value()) {
+      base::unex_ = std::forward<Other>(other).unex_;
+    } else if (has_value() && !other.has_value()) {
+      construct_error(std::forward<Other>(other).unex_);
+    } else if (!has_value() && other.has_value()) {
+      base::destroy();
+    }
+  }
+};
+
+// Extra deletion of copy/move assignment beyond what cond_trivial_smf expresses:
+// [expected.object.assign] also requires (is_nothrow_move_constructible<T> || is_nothrow_move_constructible<E>).
+template<bool Enable>
+struct expected_assign_guard {
+  expected_assign_guard() = default;
+  expected_assign_guard(expected_assign_guard const&) = default;
+  expected_assign_guard(expected_assign_guard&&) = default;
+  expected_assign_guard& operator=(expected_assign_guard const&) = default;
+  expected_assign_guard& operator=(expected_assign_guard&&) = default;
+};
+
+template<>
+struct expected_assign_guard<false> {
+  expected_assign_guard() = default;
+  expected_assign_guard(expected_assign_guard const&) = default;
+  expected_assign_guard(expected_assign_guard&&) = default;
+  expected_assign_guard& operator=(expected_assign_guard const&) = delete;
+  expected_assign_guard& operator=(expected_assign_guard&&) = delete;
+};
+
+// converting-constructor constraints [expected.object.cons]
+
+template<class T, class E, class U, class G, class UF, class GF>
+struct expected_can_convert {
+  static constexpr bool value = std::is_constructible<T, UF>::value && std::is_constructible<E, GF>::value && !converts_from_any_cvref<T, expected<U, G>>::value
+                                && !constructs_from_any_cvref<unexpected<E>, expected<U, G>>::value;
+};
+
+template<class E, class G, class GF>
+struct expected_void_can_convert {
+  static constexpr bool value = std::is_constructible<E, GF>::value && !constructs_from_any_cvref<unexpected<E>, expected<void, G>>::value;
+};
+
+// transform helpers: build expected<U, E2> from invoking f, U possibly void
+
+template<class Exp, class F, class... Args>
+YK_POLYFILL_CXX14_CONSTEXPR Exp expected_transform_make(false_type /* U is void */, F&& f, Args&&... args)
+{
+  return Exp(in_place, polyfill::invoke(std::forward<F>(f), std::forward<Args>(args)...));
+}
+
+template<class Exp, class F, class... Args>
+YK_POLYFILL_CXX14_CONSTEXPR Exp expected_transform_make(true_type /* U is void */, F&& f, Args&&... args)
+{
+  polyfill::invoke(std::forward<F>(f), std::forward<Args>(args)...);
+  return Exp(in_place);
+}
+
+}  // namespace detail
+
+//
+// expected<T, E>
+//
+
+template<class T, class E>
+class expected : private detail::cond_trivial_smf<detail::expected_storage_base<T, E>, T, E>,
+                 private detail::expected_assign_guard<std::is_nothrow_move_constructible<T>::value || std::is_nothrow_move_constructible<E>::value> {
+private:
+  using base_type = detail::cond_trivial_smf<detail::expected_storage_base<T, E>, T, E>;
+
+  static_assert(!std::is_void<T>::value, "primary template requires a non-void T");
+  static_assert(std::is_object<T>::value, "T must be an object type");
+  static_assert(!std::is_array<T>::value, "T must not be an array type");
+  static_assert(!std::is_reference<T>::value, "T must not be a reference type");
+  static_assert(!std::is_same<typename std::remove_cv<T>::type, in_place_t>::value, "T must not be in_place_t");
+  static_assert(!std::is_same<typename std::remove_cv<T>::type, unexpect_t>::value, "T must not be unexpect_t");
+  static_assert(!detail::is_unexpected<typename std::remove_cv<T>::type>::value, "T must not be a specialization of unexpected");
+  static_assert(std::is_object<E>::value && !std::is_array<E>::value && !std::is_const<E>::value && !std::is_volatile<E>::value,
+                "E must be a valid unexpected type");
+
+public:
+  using value_type = T;
+  using error_type = E;
+  using unexpected_type = unexpected<E>;
+
+  template<class U>
+  using rebind = expected<U, error_type>;
+
+  // constructors
+
+  template<class T2 = T, typename std::enable_if<std::is_default_constructible<T2>::value, std::nullptr_t>::type = nullptr>
+  constexpr expected() noexcept(std::is_nothrow_default_constructible<T>::value) : base_type(in_place)
+  {
+  }
+
+  // copy/move constructors are implicit (provided by cond_trivial_smf base)
+
+  template<class U, class G,
+           typename std::enable_if<detail::expected_can_convert<T, E, U, G, U const&, G const&>::value && std::is_convertible<U const&, T>::value
+                                       && std::is_convertible<G const&, E>::value,
+                                   std::nullptr_t>::type = nullptr>
+  YK_POLYFILL_CXX20_CONSTEXPR expected(expected<U, G> const& rhs)
+      noexcept(std::is_nothrow_constructible<T, U const&>::value && std::is_nothrow_constructible<E, G const&>::value)
+      : base_type()
+  {
+    if (rhs.has_value()) {
+      this->construct_value(*rhs);
+    } else {
+      this->construct_error(rhs.error());
+    }
+  }
+
+  template<class U, class G,
+           typename std::enable_if<detail::expected_can_convert<T, E, U, G, U const&, G const&>::value
+                                       && !(std::is_convertible<U const&, T>::value && std::is_convertible<G const&, E>::value),
+                                   std::nullptr_t>::type = nullptr>
+  YK_POLYFILL_CXX20_CONSTEXPR explicit expected(expected<U, G> const& rhs)
+      noexcept(std::is_nothrow_constructible<T, U const&>::value && std::is_nothrow_constructible<E, G const&>::value)
+      : base_type()
+  {
+    if (rhs.has_value()) {
+      this->construct_value(*rhs);
+    } else {
+      this->construct_error(rhs.error());
+    }
+  }
+
+  template<
+      class U, class G,
+      typename std::enable_if<detail::expected_can_convert<T, E, U, G, U, G>::value && std::is_convertible<U, T>::value && std::is_convertible<G, E>::value,
+                              std::nullptr_t>::type = nullptr>
+  YK_POLYFILL_CXX20_CONSTEXPR expected(expected<U, G>&& rhs) noexcept(std::is_nothrow_constructible<T, U>::value && std::is_nothrow_constructible<E, G>::value)
+      : base_type()
+  {
+    if (rhs.has_value()) {
+      this->construct_value(*std::move(rhs));
+    } else {
+      this->construct_error(std::move(rhs).error());
+    }
+  }
+
+  template<
+      class U, class G,
+      typename std::enable_if<detail::expected_can_convert<T, E, U, G, U, G>::value && !(std::is_convertible<U, T>::value && std::is_convertible<G, E>::value),
+                              std::nullptr_t>::type = nullptr>
+  YK_POLYFILL_CXX20_CONSTEXPR explicit expected(expected<U, G>&& rhs)
+      noexcept(std::is_nothrow_constructible<T, U>::value && std::is_nothrow_constructible<E, G>::value)
+      : base_type()
+  {
+    if (rhs.has_value()) {
+      this->construct_value(*std::move(rhs));
+    } else {
+      this->construct_error(std::move(rhs).error());
+    }
+  }
+
+  template<class U = T, typename std::enable_if<
+                            !std::is_same<typename remove_cvref<U>::type, in_place_t>::value && !std::is_same<typename remove_cvref<U>::type, expected>::value
+                                && !detail::is_unexpected<typename remove_cvref<U>::type>::value && std::is_constructible<T, U>::value
+                                && (!std::is_same<typename std::remove_cv<T>::type, bool>::value || !detail::is_expected<typename remove_cvref<U>::type>::value)
+                                && std::is_convertible<U, T>::value,
+                            std::nullptr_t>::type = nullptr>
+  constexpr expected(U&& v) noexcept(std::is_nothrow_constructible<T, U>::value) : base_type(in_place, std::forward<U>(v))
+  {
+  }
+
+  template<class U = T, typename std::enable_if<
+                            !std::is_same<typename remove_cvref<U>::type, in_place_t>::value && !std::is_same<typename remove_cvref<U>::type, expected>::value
+                                && !detail::is_unexpected<typename remove_cvref<U>::type>::value && std::is_constructible<T, U>::value
+                                && (!std::is_same<typename std::remove_cv<T>::type, bool>::value || !detail::is_expected<typename remove_cvref<U>::type>::value)
+                                && !std::is_convertible<U, T>::value,
+                            std::nullptr_t>::type = nullptr>
+  constexpr explicit expected(U&& v) noexcept(std::is_nothrow_constructible<T, U>::value) : base_type(in_place, std::forward<U>(v))
+  {
+  }
+
+  template<class G,
+           typename std::enable_if<std::is_constructible<E, G const&>::value && std::is_convertible<G const&, E>::value, std::nullptr_t>::type = nullptr>
+  constexpr expected(unexpected<G> const& e) noexcept(std::is_nothrow_constructible<E, G const&>::value) : base_type(unexpect, e.error())
+  {
+  }
+
+  template<class G,
+           typename std::enable_if<std::is_constructible<E, G const&>::value && !std::is_convertible<G const&, E>::value, std::nullptr_t>::type = nullptr>
+  constexpr explicit expected(unexpected<G> const& e) noexcept(std::is_nothrow_constructible<E, G const&>::value) : base_type(unexpect, e.error())
+  {
+  }
+
+  template<class G, typename std::enable_if<std::is_constructible<E, G>::value && std::is_convertible<G, E>::value, std::nullptr_t>::type = nullptr>
+  constexpr expected(unexpected<G>&& e) noexcept(std::is_nothrow_constructible<E, G>::value) : base_type(unexpect, std::move(e).error())
+  {
+  }
+
+  template<class G, typename std::enable_if<std::is_constructible<E, G>::value && !std::is_convertible<G, E>::value, std::nullptr_t>::type = nullptr>
+  constexpr explicit expected(unexpected<G>&& e) noexcept(std::is_nothrow_constructible<E, G>::value) : base_type(unexpect, std::move(e).error())
+  {
+  }
+
+  template<class... Args, typename std::enable_if<std::is_constructible<T, Args...>::value, std::nullptr_t>::type = nullptr>
+  constexpr explicit expected(in_place_t, Args&&... args) noexcept(std::is_nothrow_constructible<T, Args...>::value)
+      : base_type(in_place, std::forward<Args>(args)...)
+  {
+  }
+
+  template<class U, class... Args, typename std::enable_if<std::is_constructible<T, std::initializer_list<U>&, Args...>::value, std::nullptr_t>::type = nullptr>
+  constexpr explicit expected(in_place_t, std::initializer_list<U> il, Args&&... args)
+      noexcept(std::is_nothrow_constructible<T, std::initializer_list<U>&, Args...>::value)
+      : base_type(in_place, il, std::forward<Args>(args)...)
+  {
+  }
+
+  template<class... Args, typename std::enable_if<std::is_constructible<E, Args...>::value, std::nullptr_t>::type = nullptr>
+  constexpr explicit expected(unexpect_t, Args&&... args) noexcept(std::is_nothrow_constructible<E, Args...>::value)
+      : base_type(unexpect, std::forward<Args>(args)...)
+  {
+  }
+
+  template<class U, class... Args, typename std::enable_if<std::is_constructible<E, std::initializer_list<U>&, Args...>::value, std::nullptr_t>::type = nullptr>
+  constexpr explicit expected(unexpect_t, std::initializer_list<U> il, Args&&... args)
+      noexcept(std::is_nothrow_constructible<E, std::initializer_list<U>&, Args...>::value)
+      : base_type(unexpect, il, std::forward<Args>(args)...)
+  {
+  }
+
+  // assignment (copy/move assignment are implicit)
+
+  template<class U = T, typename std::enable_if<!std::is_same<typename remove_cvref<U>::type, expected>::value
+                                                    && !detail::is_unexpected<typename remove_cvref<U>::type>::value && std::is_constructible<T, U>::value
+                                                    && std::is_assignable<T&, U>::value
+                                                    && (std::is_nothrow_constructible<T, U>::value || std::is_nothrow_move_constructible<T>::value
+                                                        || std::is_nothrow_move_constructible<E>::value),
+                                                std::nullptr_t>::type = nullptr>
+  YK_POLYFILL_CXX20_CONSTEXPR expected& operator=(U&& v)
+  {
+    if (has_value()) {
+      this->get_value() = std::forward<U>(v);
+    } else {
+      this->reinit_to_value(std::forward<U>(v));
+    }
+    return *this;
+  }
+
+  template<class G, typename std::enable_if<std::is_constructible<E, G const&>::value && std::is_assignable<E&, G const&>::value
+                                                && (std::is_nothrow_constructible<E, G const&>::value || std::is_nothrow_move_constructible<T>::value
+                                                    || std::is_nothrow_move_constructible<E>::value),
+                                            std::nullptr_t>::type = nullptr>
+  YK_POLYFILL_CXX20_CONSTEXPR expected& operator=(unexpected<G> const& e)
+  {
+    if (has_value()) {
+      this->reinit_to_error(e.error());
+    } else {
+      this->get_error() = e.error();
+    }
+    return *this;
+  }
+
+  template<class G, typename std::enable_if<std::is_constructible<E, G>::value && std::is_assignable<E&, G>::value
+                                                && (std::is_nothrow_constructible<E, G>::value || std::is_nothrow_move_constructible<T>::value
+                                                    || std::is_nothrow_move_constructible<E>::value),
+                                            std::nullptr_t>::type = nullptr>
+  YK_POLYFILL_CXX20_CONSTEXPR expected& operator=(unexpected<G>&& e)
+  {
+    if (has_value()) {
+      this->reinit_to_error(std::move(e).error());
+    } else {
+      this->get_error() = std::move(e).error();
+    }
+    return *this;
+  }
+
+  template<class... Args, typename std::enable_if<std::is_nothrow_constructible<T, Args...>::value, std::nullptr_t>::type = nullptr>
+  YK_POLYFILL_CXX20_CONSTEXPR T& emplace(Args&&... args) noexcept
+  {
+    this->destroy();
+    this->construct_value(std::forward<Args>(args)...);
+    return this->get_value();
+  }
+
+  template<class U, class... Args,
+           typename std::enable_if<std::is_nothrow_constructible<T, std::initializer_list<U>&, Args...>::value, std::nullptr_t>::type = nullptr>
+  YK_POLYFILL_CXX20_CONSTEXPR T& emplace(std::initializer_list<U> il, Args&&... args) noexcept
+  {
+    this->destroy();
+    this->construct_value(il, std::forward<Args>(args)...);
+    return this->get_value();
+  }
+
+  // swap
+
+  YK_POLYFILL_CXX20_CONSTEXPR void swap(expected& rhs) noexcept(std::is_nothrow_move_constructible<T>::value && is_nothrow_swappable<T>::value
+                                                                && std::is_nothrow_move_constructible<E>::value && is_nothrow_swappable<E>::value)
+  {
+    static_assert(is_swappable<T>::value && is_swappable<E>::value && std::is_move_constructible<T>::value && std::is_move_constructible<E>::value
+                      && (std::is_nothrow_move_constructible<T>::value || std::is_nothrow_move_constructible<E>::value),
+                  "expected::swap requirements not met");
+    if (rhs.has_value()) {
+      if (has_value()) {
+        using std::swap;
+        swap(this->get_value(), rhs.get_value());
+      } else {
+        rhs.swap(*this);
+      }
+    } else {
+      if (has_value()) {
+        swap_value_error(rhs, integral_constant<bool, std::is_nothrow_move_constructible<E>::value>{});
+      } else {
+        using std::swap;
+        swap(this->get_error(), rhs.get_error());
+      }
+    }
+  }
+
+  // observers
+
+  [[nodiscard]] YK_POLYFILL_CXX14_CONSTEXPR T const* operator->() const noexcept { return std::addressof(this->get_value()); }
+  [[nodiscard]] YK_POLYFILL_CXX14_CONSTEXPR T* operator->() noexcept { return std::addressof(this->get_value()); }
+
+  [[nodiscard]] constexpr T const& operator*() const& noexcept { return this->get_value(); }
+  [[nodiscard]] YK_POLYFILL_CXX14_CONSTEXPR T& operator*() & noexcept { return this->get_value(); }
+  [[nodiscard]] constexpr T const&& operator*() const&& noexcept { return std::move(*this).base_get_value(); }
+  [[nodiscard]] YK_POLYFILL_CXX14_CONSTEXPR T&& operator*() && noexcept { return std::move(*this).base_get_value(); }
+
+  [[nodiscard]] constexpr explicit operator bool() const noexcept { return has_value(); }
+  [[nodiscard]] constexpr bool has_value() const noexcept { return base_type::has_value(); }
+
+  YK_POLYFILL_CXX14_CONSTEXPR T& value() &
+  {
+    if (has_value()) return this->get_value();
+    throw bad_expected_access<E>(this->get_error());
+  }
+  YK_POLYFILL_CXX14_CONSTEXPR T const& value() const&
+  {
+    if (has_value()) return this->get_value();
+    throw bad_expected_access<E>(this->get_error());
+  }
+  YK_POLYFILL_CXX14_CONSTEXPR T&& value() &&
+  {
+    if (has_value()) return std::move(this->get_value());
+    throw bad_expected_access<E>(std::move(this->get_error()));
+  }
+  YK_POLYFILL_CXX14_CONSTEXPR T const&& value() const&&
+  {
+    if (has_value()) return std::move(this->get_value());
+    throw bad_expected_access<E>(std::move(this->get_error()));
+  }
+
+  [[nodiscard]] constexpr E const& error() const& noexcept { return this->get_error(); }
+  [[nodiscard]] YK_POLYFILL_CXX14_CONSTEXPR E& error() & noexcept { return this->get_error(); }
+  [[nodiscard]] constexpr E const&& error() const&& noexcept { return std::move(*this).base_get_error(); }
+  [[nodiscard]] YK_POLYFILL_CXX14_CONSTEXPR E&& error() && noexcept { return std::move(*this).base_get_error(); }
+
+  template<class U = typename std::remove_cv<T>::type>
+  YK_POLYFILL_CXX14_CONSTEXPR T value_or(U&& v) const&
+  {
+    static_assert(std::is_copy_constructible<T>::value && std::is_convertible<U, T>::value, "T must be copy constructible and the argument convertible to T");
+    return has_value() ? this->get_value() : static_cast<T>(std::forward<U>(v));
+  }
+
+  template<class U = typename std::remove_cv<T>::type>
+  YK_POLYFILL_CXX14_CONSTEXPR T value_or(U&& v) &&
+  {
+    static_assert(std::is_move_constructible<T>::value && std::is_convertible<U, T>::value, "T must be move constructible and the argument convertible to T");
+    return has_value() ? std::move(this->get_value()) : static_cast<T>(std::forward<U>(v));
+  }
+
+  template<class G = E>
+  YK_POLYFILL_CXX14_CONSTEXPR E error_or(G&& e) const&
+  {
+    static_assert(std::is_copy_constructible<E>::value && std::is_convertible<G, E>::value, "E must be copy constructible and the argument convertible to E");
+    return has_value() ? static_cast<E>(std::forward<G>(e)) : this->get_error();
+  }
+
+  template<class G = E>
+  YK_POLYFILL_CXX14_CONSTEXPR E error_or(G&& e) &&
+  {
+    static_assert(std::is_move_constructible<E>::value && std::is_convertible<G, E>::value, "E must be move constructible and the argument convertible to E");
+    return has_value() ? static_cast<E>(std::forward<G>(e)) : std::move(this->get_error());
+  }
+
+  // monadic operations
+
+  template<class F>
+  YK_POLYFILL_CXX14_CONSTEXPR auto and_then(F&& f) & -> typename remove_cvref<typename invoke_result<F, T&>::type>::type
+  {
+    using U = typename remove_cvref<typename invoke_result<F, T&>::type>::type;
+    static_assert(detail::is_expected<U>::value, "result of F must be a specialization of expected");
+    static_assert(std::is_same<typename U::error_type, E>::value, "F's expected result must have the same error_type");
+    if (has_value()) return polyfill::invoke(std::forward<F>(f), this->get_value());
+    return U(unexpect, this->get_error());
+  }
+
+  template<class F>
+  YK_POLYFILL_CXX14_CONSTEXPR auto and_then(F&& f) const& -> typename remove_cvref<typename invoke_result<F, T const&>::type>::type
+  {
+    using U = typename remove_cvref<typename invoke_result<F, T const&>::type>::type;
+    static_assert(detail::is_expected<U>::value, "result of F must be a specialization of expected");
+    static_assert(std::is_same<typename U::error_type, E>::value, "F's expected result must have the same error_type");
+    if (has_value()) return polyfill::invoke(std::forward<F>(f), this->get_value());
+    return U(unexpect, this->get_error());
+  }
+
+  template<class F>
+  YK_POLYFILL_CXX14_CONSTEXPR auto and_then(F&& f) && -> typename remove_cvref<typename invoke_result<F, T&&>::type>::type
+  {
+    using U = typename remove_cvref<typename invoke_result<F, T&&>::type>::type;
+    static_assert(detail::is_expected<U>::value, "result of F must be a specialization of expected");
+    static_assert(std::is_same<typename U::error_type, E>::value, "F's expected result must have the same error_type");
+    if (has_value()) return polyfill::invoke(std::forward<F>(f), std::move(this->get_value()));
+    return U(unexpect, std::move(this->get_error()));
+  }
+
+  template<class F>
+  YK_POLYFILL_CXX14_CONSTEXPR auto and_then(F&& f) const&& -> typename remove_cvref<typename invoke_result<F, T const&&>::type>::type
+  {
+    using U = typename remove_cvref<typename invoke_result<F, T const&&>::type>::type;
+    static_assert(detail::is_expected<U>::value, "result of F must be a specialization of expected");
+    static_assert(std::is_same<typename U::error_type, E>::value, "F's expected result must have the same error_type");
+    if (has_value()) return polyfill::invoke(std::forward<F>(f), std::move(this->get_value()));
+    return U(unexpect, std::move(this->get_error()));
+  }
+
+  template<class F>
+  YK_POLYFILL_CXX14_CONSTEXPR auto or_else(F&& f) & -> typename remove_cvref<typename invoke_result<F, E&>::type>::type
+  {
+    using G = typename remove_cvref<typename invoke_result<F, E&>::type>::type;
+    static_assert(detail::is_expected<G>::value, "result of F must be a specialization of expected");
+    static_assert(std::is_same<typename G::value_type, T>::value, "F's expected result must have the same value_type");
+    if (has_value()) return G(in_place, this->get_value());
+    return polyfill::invoke(std::forward<F>(f), this->get_error());
+  }
+
+  template<class F>
+  YK_POLYFILL_CXX14_CONSTEXPR auto or_else(F&& f) const& -> typename remove_cvref<typename invoke_result<F, E const&>::type>::type
+  {
+    using G = typename remove_cvref<typename invoke_result<F, E const&>::type>::type;
+    static_assert(detail::is_expected<G>::value, "result of F must be a specialization of expected");
+    static_assert(std::is_same<typename G::value_type, T>::value, "F's expected result must have the same value_type");
+    if (has_value()) return G(in_place, this->get_value());
+    return polyfill::invoke(std::forward<F>(f), this->get_error());
+  }
+
+  template<class F>
+  YK_POLYFILL_CXX14_CONSTEXPR auto or_else(F&& f) && -> typename remove_cvref<typename invoke_result<F, E&&>::type>::type
+  {
+    using G = typename remove_cvref<typename invoke_result<F, E&&>::type>::type;
+    static_assert(detail::is_expected<G>::value, "result of F must be a specialization of expected");
+    static_assert(std::is_same<typename G::value_type, T>::value, "F's expected result must have the same value_type");
+    if (has_value()) return G(in_place, std::move(this->get_value()));
+    return polyfill::invoke(std::forward<F>(f), std::move(this->get_error()));
+  }
+
+  template<class F>
+  YK_POLYFILL_CXX14_CONSTEXPR auto or_else(F&& f) const&& -> typename remove_cvref<typename invoke_result<F, E const&&>::type>::type
+  {
+    using G = typename remove_cvref<typename invoke_result<F, E const&&>::type>::type;
+    static_assert(detail::is_expected<G>::value, "result of F must be a specialization of expected");
+    static_assert(std::is_same<typename G::value_type, T>::value, "F's expected result must have the same value_type");
+    if (has_value()) return G(in_place, std::move(this->get_value()));
+    return polyfill::invoke(std::forward<F>(f), std::move(this->get_error()));
+  }
+
+  template<class F>
+  YK_POLYFILL_CXX14_CONSTEXPR auto transform(F&& f) & -> expected<typename std::remove_cv<typename invoke_result<F, T&>::type>::type, E>
+  {
+    using U = typename std::remove_cv<typename invoke_result<F, T&>::type>::type;
+    if (has_value()) return detail::expected_transform_make<expected<U, E>>(bool_constant<std::is_void<U>::value>{}, std::forward<F>(f), this->get_value());
+    return expected<U, E>(unexpect, this->get_error());
+  }
+
+  template<class F>
+  YK_POLYFILL_CXX14_CONSTEXPR auto transform(F&& f) const& -> expected<typename std::remove_cv<typename invoke_result<F, T const&>::type>::type, E>
+  {
+    using U = typename std::remove_cv<typename invoke_result<F, T const&>::type>::type;
+    if (has_value()) return detail::expected_transform_make<expected<U, E>>(bool_constant<std::is_void<U>::value>{}, std::forward<F>(f), this->get_value());
+    return expected<U, E>(unexpect, this->get_error());
+  }
+
+  template<class F>
+  YK_POLYFILL_CXX14_CONSTEXPR auto transform(F&& f) && -> expected<typename std::remove_cv<typename invoke_result<F, T&&>::type>::type, E>
+  {
+    using U = typename std::remove_cv<typename invoke_result<F, T&&>::type>::type;
+    if (has_value())
+      return detail::expected_transform_make<expected<U, E>>(bool_constant<std::is_void<U>::value>{}, std::forward<F>(f), std::move(this->get_value()));
+    return expected<U, E>(unexpect, std::move(this->get_error()));
+  }
+
+  template<class F>
+  YK_POLYFILL_CXX14_CONSTEXPR auto transform(F&& f) const&& -> expected<typename std::remove_cv<typename invoke_result<F, T const&&>::type>::type, E>
+  {
+    using U = typename std::remove_cv<typename invoke_result<F, T const&&>::type>::type;
+    if (has_value())
+      return detail::expected_transform_make<expected<U, E>>(bool_constant<std::is_void<U>::value>{}, std::forward<F>(f), std::move(this->get_value()));
+    return expected<U, E>(unexpect, std::move(this->get_error()));
+  }
+
+  template<class F>
+  YK_POLYFILL_CXX14_CONSTEXPR auto transform_error(F&& f) & -> expected<T, typename std::remove_cv<typename invoke_result<F, E&>::type>::type>
+  {
+    using G = typename std::remove_cv<typename invoke_result<F, E&>::type>::type;
+    if (has_value()) return expected<T, G>(in_place, this->get_value());
+    return expected<T, G>(unexpect, polyfill::invoke(std::forward<F>(f), this->get_error()));
+  }
+
+  template<class F>
+  YK_POLYFILL_CXX14_CONSTEXPR auto transform_error(F&& f) const& -> expected<T, typename std::remove_cv<typename invoke_result<F, E const&>::type>::type>
+  {
+    using G = typename std::remove_cv<typename invoke_result<F, E const&>::type>::type;
+    if (has_value()) return expected<T, G>(in_place, this->get_value());
+    return expected<T, G>(unexpect, polyfill::invoke(std::forward<F>(f), this->get_error()));
+  }
+
+  template<class F>
+  YK_POLYFILL_CXX14_CONSTEXPR auto transform_error(F&& f) && -> expected<T, typename std::remove_cv<typename invoke_result<F, E&&>::type>::type>
+  {
+    using G = typename std::remove_cv<typename invoke_result<F, E&&>::type>::type;
+    if (has_value()) return expected<T, G>(in_place, std::move(this->get_value()));
+    return expected<T, G>(unexpect, polyfill::invoke(std::forward<F>(f), std::move(this->get_error())));
+  }
+
+  template<class F>
+  YK_POLYFILL_CXX14_CONSTEXPR auto transform_error(F&& f) const&& -> expected<T, typename std::remove_cv<typename invoke_result<F, E const&&>::type>::type>
+  {
+    using G = typename std::remove_cv<typename invoke_result<F, E const&&>::type>::type;
+    if (has_value()) return expected<T, G>(in_place, std::move(this->get_value()));
+    return expected<T, G>(unexpect, polyfill::invoke(std::forward<F>(f), std::move(this->get_error())));
+  }
+
+private:
+  // rvalue accessors on the storage (private base), reached through explicit std::move.
+  YK_POLYFILL_CXX14_CONSTEXPR T&& base_get_value() && noexcept { return std::move(static_cast<base_type&>(*this).get_value()); }
+  YK_POLYFILL_CXX14_CONSTEXPR T const&& base_get_value() const&& noexcept { return std::move(static_cast<base_type const&>(*this).get_value()); }
+  YK_POLYFILL_CXX14_CONSTEXPR E&& base_get_error() && noexcept { return std::move(static_cast<base_type&>(*this).get_error()); }
+  YK_POLYFILL_CXX14_CONSTEXPR E const&& base_get_error() const&& noexcept { return std::move(static_cast<base_type const&>(*this).get_error()); }
+
+  // this holds a value, rhs holds an error; leave this holding rhs's error and rhs holding this's value.
+  YK_POLYFILL_CXX20_CONSTEXPR void swap_value_error(expected& rhs, true_type /* E is nothrow move constructible */)
+  {
+    E tmp(std::move(rhs.get_error()));
+    rhs.destroy();
+    try {
+      rhs.construct_value(std::move(this->get_value()));
+      this->destroy();
+      this->construct_error(std::move(tmp));
+    } catch (...) {
+      rhs.construct_error(std::move(tmp));
+      throw;
+    }
+  }
+
+  YK_POLYFILL_CXX20_CONSTEXPR void swap_value_error(expected& rhs, false_type /* rely on T nothrow move constructible */)
+  {
+    T tmp(std::move(this->get_value()));
+    this->destroy();
+    try {
+      this->construct_error(std::move(rhs.get_error()));
+      rhs.destroy();
+      rhs.construct_value(std::move(tmp));
+    } catch (...) {
+      this->construct_value(std::move(tmp));
+      throw;
+    }
+  }
+};
+
+//
+// expected<void, E>
+//
+
+template<class E>
+class expected<void, E> : private detail::cond_trivial_smf<detail::expected_void_storage_base<E>, E> {
+private:
+  using base_type = detail::cond_trivial_smf<detail::expected_void_storage_base<E>, E>;
+
+  static_assert(std::is_object<E>::value && !std::is_array<E>::value && !std::is_const<E>::value && !std::is_volatile<E>::value,
+                "E must be a valid unexpected type");
+
+public:
+  using value_type = void;
+  using error_type = E;
+  using unexpected_type = unexpected<E>;
+
+  template<class U>
+  using rebind = expected<U, error_type>;
+
+  constexpr expected() noexcept : base_type(in_place) {}
+
+  // copy/move constructors are implicit (provided by cond_trivial_smf base)
+
+  template<
+      class U, class G,
+      typename std::enable_if<std::is_void<U>::value && detail::expected_void_can_convert<E, G, G const&>::value && std::is_convertible<G const&, E>::value,
+                              std::nullptr_t>::type = nullptr>
+  YK_POLYFILL_CXX20_CONSTEXPR expected(expected<U, G> const& rhs) noexcept(std::is_nothrow_constructible<E, G const&>::value) : base_type()
+  {
+    if (!rhs.has_value()) {
+      this->construct_error(rhs.error());
+    }
+  }
+
+  template<
+      class U, class G,
+      typename std::enable_if<std::is_void<U>::value && detail::expected_void_can_convert<E, G, G const&>::value && !std::is_convertible<G const&, E>::value,
+                              std::nullptr_t>::type = nullptr>
+  YK_POLYFILL_CXX20_CONSTEXPR explicit expected(expected<U, G> const& rhs) noexcept(std::is_nothrow_constructible<E, G const&>::value) : base_type()
+  {
+    if (!rhs.has_value()) {
+      this->construct_error(rhs.error());
+    }
+  }
+
+  template<class U, class G,
+           typename std::enable_if<std::is_void<U>::value && detail::expected_void_can_convert<E, G, G>::value && std::is_convertible<G, E>::value,
+                                   std::nullptr_t>::type = nullptr>
+  YK_POLYFILL_CXX20_CONSTEXPR expected(expected<U, G>&& rhs) noexcept(std::is_nothrow_constructible<E, G>::value) : base_type()
+  {
+    if (!rhs.has_value()) {
+      this->construct_error(std::move(rhs).error());
+    }
+  }
+
+  template<class U, class G,
+           typename std::enable_if<std::is_void<U>::value && detail::expected_void_can_convert<E, G, G>::value && !std::is_convertible<G, E>::value,
+                                   std::nullptr_t>::type = nullptr>
+  YK_POLYFILL_CXX20_CONSTEXPR explicit expected(expected<U, G>&& rhs) noexcept(std::is_nothrow_constructible<E, G>::value) : base_type()
+  {
+    if (!rhs.has_value()) {
+      this->construct_error(std::move(rhs).error());
+    }
+  }
+
+  template<class G,
+           typename std::enable_if<std::is_constructible<E, G const&>::value && std::is_convertible<G const&, E>::value, std::nullptr_t>::type = nullptr>
+  constexpr expected(unexpected<G> const& e) noexcept(std::is_nothrow_constructible<E, G const&>::value) : base_type(unexpect, e.error())
+  {
+  }
+
+  template<class G,
+           typename std::enable_if<std::is_constructible<E, G const&>::value && !std::is_convertible<G const&, E>::value, std::nullptr_t>::type = nullptr>
+  constexpr explicit expected(unexpected<G> const& e) noexcept(std::is_nothrow_constructible<E, G const&>::value) : base_type(unexpect, e.error())
+  {
+  }
+
+  template<class G, typename std::enable_if<std::is_constructible<E, G>::value && std::is_convertible<G, E>::value, std::nullptr_t>::type = nullptr>
+  constexpr expected(unexpected<G>&& e) noexcept(std::is_nothrow_constructible<E, G>::value) : base_type(unexpect, std::move(e).error())
+  {
+  }
+
+  template<class G, typename std::enable_if<std::is_constructible<E, G>::value && !std::is_convertible<G, E>::value, std::nullptr_t>::type = nullptr>
+  constexpr explicit expected(unexpected<G>&& e) noexcept(std::is_nothrow_constructible<E, G>::value) : base_type(unexpect, std::move(e).error())
+  {
+  }
+
+  constexpr explicit expected(in_place_t) noexcept : base_type(in_place) {}
+
+  template<class... Args, typename std::enable_if<std::is_constructible<E, Args...>::value, std::nullptr_t>::type = nullptr>
+  constexpr explicit expected(unexpect_t, Args&&... args) noexcept(std::is_nothrow_constructible<E, Args...>::value)
+      : base_type(unexpect, std::forward<Args>(args)...)
+  {
+  }
+
+  template<class U, class... Args, typename std::enable_if<std::is_constructible<E, std::initializer_list<U>&, Args...>::value, std::nullptr_t>::type = nullptr>
+  constexpr explicit expected(unexpect_t, std::initializer_list<U> il, Args&&... args)
+      noexcept(std::is_nothrow_constructible<E, std::initializer_list<U>&, Args...>::value)
+      : base_type(unexpect, il, std::forward<Args>(args)...)
+  {
+  }
+
+  // assignment (copy/move assignment are implicit)
+
+  template<class G,
+           typename std::enable_if<std::is_constructible<E, G const&>::value && std::is_assignable<E&, G const&>::value, std::nullptr_t>::type = nullptr>
+  YK_POLYFILL_CXX20_CONSTEXPR expected& operator=(unexpected<G> const& e)
+  {
+    if (has_value()) {
+      this->construct_error(e.error());
+    } else {
+      this->get_error() = e.error();
+    }
+    return *this;
+  }
+
+  template<class G, typename std::enable_if<std::is_constructible<E, G>::value && std::is_assignable<E&, G>::value, std::nullptr_t>::type = nullptr>
+  YK_POLYFILL_CXX20_CONSTEXPR expected& operator=(unexpected<G>&& e)
+  {
+    if (has_value()) {
+      this->construct_error(std::move(e).error());
+    } else {
+      this->get_error() = std::move(e).error();
+    }
+    return *this;
+  }
+
+  YK_POLYFILL_CXX20_CONSTEXPR void emplace() noexcept { this->destroy(); }
+
+  YK_POLYFILL_CXX20_CONSTEXPR void swap(expected& rhs) noexcept(std::is_nothrow_move_constructible<E>::value && is_nothrow_swappable<E>::value)
+  {
+    static_assert(is_swappable<E>::value && std::is_move_constructible<E>::value, "expected<void, E>::swap requirements not met");
+    if (rhs.has_value()) {
+      if (!has_value()) {
+        rhs.construct_error(std::move(this->get_error()));
+        this->destroy();
+      }
+    } else {
+      if (has_value()) {
+        this->construct_error(std::move(rhs.get_error()));
+        rhs.destroy();
+      } else {
+        using std::swap;
+        swap(this->get_error(), rhs.get_error());
+      }
+    }
+  }
+
+  // observers
+
+  [[nodiscard]] constexpr explicit operator bool() const noexcept { return has_value(); }
+  [[nodiscard]] constexpr bool has_value() const noexcept { return base_type::has_value(); }
+
+  YK_POLYFILL_CXX14_CONSTEXPR void operator*() const noexcept {}
+
+  YK_POLYFILL_CXX14_CONSTEXPR void value() const&
+  {
+    if (!has_value()) throw bad_expected_access<E>(this->get_error());
+  }
+  YK_POLYFILL_CXX14_CONSTEXPR void value() &&
+  {
+    if (!has_value()) throw bad_expected_access<E>(std::move(this->get_error()));
+  }
+
+  [[nodiscard]] constexpr E const& error() const& noexcept { return this->get_error(); }
+  [[nodiscard]] YK_POLYFILL_CXX14_CONSTEXPR E& error() & noexcept { return this->get_error(); }
+  [[nodiscard]] constexpr E const&& error() const&& noexcept { return std::move(*this).base_get_error(); }
+  [[nodiscard]] YK_POLYFILL_CXX14_CONSTEXPR E&& error() && noexcept { return std::move(*this).base_get_error(); }
+
+  template<class G = E>
+  YK_POLYFILL_CXX14_CONSTEXPR E error_or(G&& e) const&
+  {
+    static_assert(std::is_copy_constructible<E>::value && std::is_convertible<G, E>::value, "E must be copy constructible and the argument convertible to E");
+    return has_value() ? static_cast<E>(std::forward<G>(e)) : this->get_error();
+  }
+
+  template<class G = E>
+  YK_POLYFILL_CXX14_CONSTEXPR E error_or(G&& e) &&
+  {
+    static_assert(std::is_move_constructible<E>::value && std::is_convertible<G, E>::value, "E must be move constructible and the argument convertible to E");
+    return has_value() ? static_cast<E>(std::forward<G>(e)) : std::move(this->get_error());
+  }
+
+  // monadic operations
+
+  template<class F>
+  YK_POLYFILL_CXX14_CONSTEXPR auto and_then(F&& f) & -> typename remove_cvref<typename invoke_result<F>::type>::type
+  {
+    using U = typename remove_cvref<typename invoke_result<F>::type>::type;
+    static_assert(detail::is_expected<U>::value, "result of F must be a specialization of expected");
+    static_assert(std::is_same<typename U::error_type, E>::value, "F's expected result must have the same error_type");
+    if (has_value()) return polyfill::invoke(std::forward<F>(f));
+    return U(unexpect, this->get_error());
+  }
+
+  template<class F>
+  YK_POLYFILL_CXX14_CONSTEXPR auto and_then(F&& f) const& -> typename remove_cvref<typename invoke_result<F>::type>::type
+  {
+    using U = typename remove_cvref<typename invoke_result<F>::type>::type;
+    static_assert(detail::is_expected<U>::value, "result of F must be a specialization of expected");
+    static_assert(std::is_same<typename U::error_type, E>::value, "F's expected result must have the same error_type");
+    if (has_value()) return polyfill::invoke(std::forward<F>(f));
+    return U(unexpect, this->get_error());
+  }
+
+  template<class F>
+  YK_POLYFILL_CXX14_CONSTEXPR auto and_then(F&& f) && -> typename remove_cvref<typename invoke_result<F>::type>::type
+  {
+    using U = typename remove_cvref<typename invoke_result<F>::type>::type;
+    static_assert(detail::is_expected<U>::value, "result of F must be a specialization of expected");
+    static_assert(std::is_same<typename U::error_type, E>::value, "F's expected result must have the same error_type");
+    if (has_value()) return polyfill::invoke(std::forward<F>(f));
+    return U(unexpect, std::move(this->get_error()));
+  }
+
+  template<class F>
+  YK_POLYFILL_CXX14_CONSTEXPR auto and_then(F&& f) const&& -> typename remove_cvref<typename invoke_result<F>::type>::type
+  {
+    using U = typename remove_cvref<typename invoke_result<F>::type>::type;
+    static_assert(detail::is_expected<U>::value, "result of F must be a specialization of expected");
+    static_assert(std::is_same<typename U::error_type, E>::value, "F's expected result must have the same error_type");
+    if (has_value()) return polyfill::invoke(std::forward<F>(f));
+    return U(unexpect, std::move(this->get_error()));
+  }
+
+  template<class F>
+  YK_POLYFILL_CXX14_CONSTEXPR auto or_else(F&& f) & -> typename remove_cvref<typename invoke_result<F, E&>::type>::type
+  {
+    using G = typename remove_cvref<typename invoke_result<F, E&>::type>::type;
+    static_assert(detail::is_expected<G>::value, "result of F must be a specialization of expected");
+    static_assert(std::is_void<typename G::value_type>::value, "F's expected result must have void value_type");
+    if (has_value()) return G();
+    return polyfill::invoke(std::forward<F>(f), this->get_error());
+  }
+
+  template<class F>
+  YK_POLYFILL_CXX14_CONSTEXPR auto or_else(F&& f) const& -> typename remove_cvref<typename invoke_result<F, E const&>::type>::type
+  {
+    using G = typename remove_cvref<typename invoke_result<F, E const&>::type>::type;
+    static_assert(detail::is_expected<G>::value, "result of F must be a specialization of expected");
+    static_assert(std::is_void<typename G::value_type>::value, "F's expected result must have void value_type");
+    if (has_value()) return G();
+    return polyfill::invoke(std::forward<F>(f), this->get_error());
+  }
+
+  template<class F>
+  YK_POLYFILL_CXX14_CONSTEXPR auto or_else(F&& f) && -> typename remove_cvref<typename invoke_result<F, E&&>::type>::type
+  {
+    using G = typename remove_cvref<typename invoke_result<F, E&&>::type>::type;
+    static_assert(detail::is_expected<G>::value, "result of F must be a specialization of expected");
+    static_assert(std::is_void<typename G::value_type>::value, "F's expected result must have void value_type");
+    if (has_value()) return G();
+    return polyfill::invoke(std::forward<F>(f), std::move(this->get_error()));
+  }
+
+  template<class F>
+  YK_POLYFILL_CXX14_CONSTEXPR auto or_else(F&& f) const&& -> typename remove_cvref<typename invoke_result<F, E const&&>::type>::type
+  {
+    using G = typename remove_cvref<typename invoke_result<F, E const&&>::type>::type;
+    static_assert(detail::is_expected<G>::value, "result of F must be a specialization of expected");
+    static_assert(std::is_void<typename G::value_type>::value, "F's expected result must have void value_type");
+    if (has_value()) return G();
+    return polyfill::invoke(std::forward<F>(f), std::move(this->get_error()));
+  }
+
+  template<class F>
+  YK_POLYFILL_CXX14_CONSTEXPR auto transform(F&& f) & -> expected<typename std::remove_cv<typename invoke_result<F>::type>::type, E>
+  {
+    using U = typename std::remove_cv<typename invoke_result<F>::type>::type;
+    if (has_value()) return detail::expected_transform_make<expected<U, E>>(bool_constant<std::is_void<U>::value>{}, std::forward<F>(f));
+    return expected<U, E>(unexpect, this->get_error());
+  }
+
+  template<class F>
+  YK_POLYFILL_CXX14_CONSTEXPR auto transform(F&& f) const& -> expected<typename std::remove_cv<typename invoke_result<F>::type>::type, E>
+  {
+    using U = typename std::remove_cv<typename invoke_result<F>::type>::type;
+    if (has_value()) return detail::expected_transform_make<expected<U, E>>(bool_constant<std::is_void<U>::value>{}, std::forward<F>(f));
+    return expected<U, E>(unexpect, this->get_error());
+  }
+
+  template<class F>
+  YK_POLYFILL_CXX14_CONSTEXPR auto transform(F&& f) && -> expected<typename std::remove_cv<typename invoke_result<F>::type>::type, E>
+  {
+    using U = typename std::remove_cv<typename invoke_result<F>::type>::type;
+    if (has_value()) return detail::expected_transform_make<expected<U, E>>(bool_constant<std::is_void<U>::value>{}, std::forward<F>(f));
+    return expected<U, E>(unexpect, std::move(this->get_error()));
+  }
+
+  template<class F>
+  YK_POLYFILL_CXX14_CONSTEXPR auto transform(F&& f) const&& -> expected<typename std::remove_cv<typename invoke_result<F>::type>::type, E>
+  {
+    using U = typename std::remove_cv<typename invoke_result<F>::type>::type;
+    if (has_value()) return detail::expected_transform_make<expected<U, E>>(bool_constant<std::is_void<U>::value>{}, std::forward<F>(f));
+    return expected<U, E>(unexpect, std::move(this->get_error()));
+  }
+
+  template<class F>
+  YK_POLYFILL_CXX14_CONSTEXPR auto transform_error(F&& f) & -> expected<void, typename std::remove_cv<typename invoke_result<F, E&>::type>::type>
+  {
+    using G = typename std::remove_cv<typename invoke_result<F, E&>::type>::type;
+    if (has_value()) return expected<void, G>();
+    return expected<void, G>(unexpect, polyfill::invoke(std::forward<F>(f), this->get_error()));
+  }
+
+  template<class F>
+  YK_POLYFILL_CXX14_CONSTEXPR auto transform_error(F&& f) const& -> expected<void, typename std::remove_cv<typename invoke_result<F, E const&>::type>::type>
+  {
+    using G = typename std::remove_cv<typename invoke_result<F, E const&>::type>::type;
+    if (has_value()) return expected<void, G>();
+    return expected<void, G>(unexpect, polyfill::invoke(std::forward<F>(f), this->get_error()));
+  }
+
+  template<class F>
+  YK_POLYFILL_CXX14_CONSTEXPR auto transform_error(F&& f) && -> expected<void, typename std::remove_cv<typename invoke_result<F, E&&>::type>::type>
+  {
+    using G = typename std::remove_cv<typename invoke_result<F, E&&>::type>::type;
+    if (has_value()) return expected<void, G>();
+    return expected<void, G>(unexpect, polyfill::invoke(std::forward<F>(f), std::move(this->get_error())));
+  }
+
+  template<class F>
+  YK_POLYFILL_CXX14_CONSTEXPR auto transform_error(F&& f) const&& -> expected<void, typename std::remove_cv<typename invoke_result<F, E const&&>::type>::type>
+  {
+    using G = typename std::remove_cv<typename invoke_result<F, E const&&>::type>::type;
+    if (has_value()) return expected<void, G>();
+    return expected<void, G>(unexpect, polyfill::invoke(std::forward<F>(f), std::move(this->get_error())));
+  }
+
+private:
+  YK_POLYFILL_CXX14_CONSTEXPR E&& base_get_error() && noexcept { return std::move(static_cast<base_type&>(*this).get_error()); }
+  YK_POLYFILL_CXX14_CONSTEXPR E const&& base_get_error() const&& noexcept { return std::move(static_cast<base_type const&>(*this).get_error()); }
+};
+
+// comparisons
+//
+// Workaround: SFINAE via return type instead of default template parameter, matching
+// variant. MSVC fails to deduce a default enable_if parameter for C++20 reversed
+// comparison candidates. In C++20 only operator== is defined (the language rewrites !=,
+// and synthesizes the reversed value==expected / unexpected==expected candidates).
+
+template<class T1, class E1, class T2, class E2>
+YK_POLYFILL_CXX14_CONSTEXPR typename std::enable_if<!std::is_void<T1>::value && !std::is_void<T2>::value
+                                                        && std::is_convertible<decltype(std::declval<T1 const&>() == std::declval<T2 const&>()), bool>::value
+                                                        && std::is_convertible<decltype(std::declval<E1 const&>() == std::declval<E2 const&>()), bool>::value,
+                                                    bool>::type
+operator==(expected<T1, E1> const& lhs, expected<T2, E2> const& rhs)
+{
+  if (lhs.has_value() != rhs.has_value()) return false;
+  if (lhs.has_value()) return static_cast<bool>(*lhs == *rhs);
+  return static_cast<bool>(lhs.error() == rhs.error());
+}
+
+template<class E1, class E2>
+YK_POLYFILL_CXX14_CONSTEXPR
+    typename std::enable_if<std::is_convertible<decltype(std::declval<E1 const&>() == std::declval<E2 const&>()), bool>::value, bool>::type
+    operator==(expected<void, E1> const& lhs, expected<void, E2> const& rhs)
+{
+  if (lhs.has_value() != rhs.has_value()) return false;
+  if (lhs.has_value()) return true;
+  return static_cast<bool>(lhs.error() == rhs.error());
+}
+
+template<class T1, class E1, class T2>
+YK_POLYFILL_CXX14_CONSTEXPR typename std::enable_if<!std::is_void<T1>::value && !detail::is_expected<T2>::value
+                                                        && std::is_convertible<decltype(std::declval<T1 const&>() == std::declval<T2 const&>()), bool>::value,
+                                                    bool>::type
+operator==(expected<T1, E1> const& lhs, T2 const& rhs)
+{
+  return lhs.has_value() && static_cast<bool>(*lhs == rhs);
+}
+
+template<class T1, class E1, class E2>
+YK_POLYFILL_CXX14_CONSTEXPR
+    typename std::enable_if<std::is_convertible<decltype(std::declval<E1 const&>() == std::declval<E2 const&>()), bool>::value, bool>::type
+    operator==(expected<T1, E1> const& lhs, unexpected<E2> const& rhs)
+{
+  return !lhs.has_value() && static_cast<bool>(lhs.error() == rhs.error());
+}
+
+#if __cplusplus < 202002L
+
+template<class T1, class E1, class T2, class E2>
+YK_POLYFILL_CXX14_CONSTEXPR typename std::enable_if<!std::is_void<T1>::value && !std::is_void<T2>::value
+                                                        && std::is_convertible<decltype(std::declval<T1 const&>() != std::declval<T2 const&>()), bool>::value
+                                                        && std::is_convertible<decltype(std::declval<E1 const&>() != std::declval<E2 const&>()), bool>::value,
+                                                    bool>::type operator!=(expected<T1, E1> const& lhs, expected<T2, E2> const& rhs)
+{
+  return !(lhs == rhs);
+}
+
+template<class E1, class E2>
+YK_POLYFILL_CXX14_CONSTEXPR
+    typename std::enable_if<std::is_convertible<decltype(std::declval<E1 const&>() != std::declval<E2 const&>()), bool>::value, bool>::type
+    operator!=(expected<void, E1> const& lhs, expected<void, E2> const& rhs)
+{
+  return !(lhs == rhs);
+}
+
+template<class T1, class E1, class T2>
+YK_POLYFILL_CXX14_CONSTEXPR typename std::enable_if<!std::is_void<T1>::value && !detail::is_expected<T2>::value
+                                                        && std::is_convertible<decltype(std::declval<T1 const&>() == std::declval<T2 const&>()), bool>::value,
+                                                    bool>::type
+operator==(T2 const& lhs, expected<T1, E1> const& rhs)
+{
+  return rhs.has_value() && static_cast<bool>(*rhs == lhs);
+}
+
+template<class T1, class E1, class T2>
+YK_POLYFILL_CXX14_CONSTEXPR typename std::enable_if<!std::is_void<T1>::value && !detail::is_expected<T2>::value
+                                                        && std::is_convertible<decltype(std::declval<T1 const&>() == std::declval<T2 const&>()), bool>::value,
+                                                    bool>::type
+operator!=(expected<T1, E1> const& lhs, T2 const& rhs)
+{
+  return !(lhs == rhs);
+}
+
+template<class T1, class E1, class T2>
+YK_POLYFILL_CXX14_CONSTEXPR typename std::enable_if<!std::is_void<T1>::value && !detail::is_expected<T2>::value
+                                                        && std::is_convertible<decltype(std::declval<T1 const&>() == std::declval<T2 const&>()), bool>::value,
+                                                    bool>::type
+operator!=(T2 const& lhs, expected<T1, E1> const& rhs)
+{
+  return !(rhs == lhs);
+}
+
+template<class T1, class E1, class E2>
+YK_POLYFILL_CXX14_CONSTEXPR
+    typename std::enable_if<std::is_convertible<decltype(std::declval<E1 const&>() == std::declval<E2 const&>()), bool>::value, bool>::type
+    operator==(unexpected<E2> const& lhs, expected<T1, E1> const& rhs)
+{
+  return !rhs.has_value() && static_cast<bool>(rhs.error() == lhs.error());
+}
+
+template<class T1, class E1, class E2>
+YK_POLYFILL_CXX14_CONSTEXPR
+    typename std::enable_if<std::is_convertible<decltype(std::declval<E1 const&>() == std::declval<E2 const&>()), bool>::value, bool>::type
+    operator!=(expected<T1, E1> const& lhs, unexpected<E2> const& rhs)
+{
+  return !(lhs == rhs);
+}
+
+template<class T1, class E1, class E2>
+YK_POLYFILL_CXX14_CONSTEXPR
+    typename std::enable_if<std::is_convertible<decltype(std::declval<E1 const&>() == std::declval<E2 const&>()), bool>::value, bool>::type
+    operator!=(unexpected<E2> const& lhs, expected<T1, E1> const& rhs)
+{
+  return !(rhs == lhs);
+}
+
+#endif
+
+template<class T, class E,
+         typename std::enable_if<(std::is_void<T>::value || std::is_move_constructible<T>::value) && std::is_move_constructible<E>::value,
+                                 std::nullptr_t>::type = nullptr>
+YK_POLYFILL_CXX20_CONSTEXPR void swap(expected<T, E>& lhs, expected<T, E>& rhs) noexcept(noexcept(lhs.swap(rhs)))
+{
+  lhs.swap(rhs);
+}
+
+}  // namespace polyfill
+
+}  // namespace yk
+
+#endif  // YK_ZZ_POLYFILL_EXPECTED_HPP

--- a/include/yk/polyfill/expected.hpp
+++ b/include/yk/polyfill/expected.hpp
@@ -552,9 +552,9 @@ struct expected_can_convert {
                                 && !constructs_from_any_cvref<unexpected<E>, expected<U, G>>::value;
 };
 
-template<class E, class G, class GF>
+template<class U, class E, class G, class GF>
 struct expected_void_can_convert {
-  static constexpr bool value = std::is_constructible<E, GF>::value && !constructs_from_any_cvref<unexpected<E>, expected<void, G>>::value;
+  static constexpr bool value = std::is_constructible<E, GF>::value && !constructs_from_any_cvref<unexpected<E>, expected<U, G>>::value;
 };
 
 // transform helpers: build expected<U, E2> from invoking f, U possibly void
@@ -670,7 +670,7 @@ public:
     }
   }
 
-  template<class U = T, typename std::enable_if<
+  template<class U = typename std::remove_cv<T>::type, typename std::enable_if<
                             !std::is_same<typename remove_cvref<U>::type, in_place_t>::value && !std::is_same<typename remove_cvref<U>::type, expected>::value
                                 && !detail::is_unexpected<typename remove_cvref<U>::type>::value && std::is_constructible<T, U>::value
                                 && (!std::is_same<typename std::remove_cv<T>::type, bool>::value || !detail::is_expected<typename remove_cvref<U>::type>::value)
@@ -680,7 +680,7 @@ public:
   {
   }
 
-  template<class U = T, typename std::enable_if<
+  template<class U = typename std::remove_cv<T>::type, typename std::enable_if<
                             !std::is_same<typename remove_cvref<U>::type, in_place_t>::value && !std::is_same<typename remove_cvref<U>::type, expected>::value
                                 && !detail::is_unexpected<typename remove_cvref<U>::type>::value && std::is_constructible<T, U>::value
                                 && (!std::is_same<typename std::remove_cv<T>::type, bool>::value || !detail::is_expected<typename remove_cvref<U>::type>::value)
@@ -740,7 +740,7 @@ public:
 
   // assignment (copy/move assignment are implicit)
 
-  template<class U = T, typename std::enable_if<!std::is_same<typename remove_cvref<U>::type, expected>::value
+  template<class U = typename std::remove_cv<T>::type, typename std::enable_if<!std::is_same<typename remove_cvref<U>::type, expected>::value
                                                     && !detail::is_unexpected<typename remove_cvref<U>::type>::value && std::is_constructible<T, U>::value
                                                     && std::is_assignable<T&, U>::value
                                                     && (std::is_nothrow_constructible<T, U>::value || std::is_nothrow_move_constructible<T>::value
@@ -844,21 +844,26 @@ public:
 
   YK_POLYFILL_CXX14_CONSTEXPR T& value() &
   {
+    static_assert(std::is_copy_constructible<E>::value, "E must be copy constructible");
     if (has_value()) return this->get_value();
     throw bad_expected_access<E>(this->get_error());
   }
   YK_POLYFILL_CXX14_CONSTEXPR T const& value() const&
   {
+    static_assert(std::is_copy_constructible<E>::value, "E must be copy constructible");
     if (has_value()) return this->get_value();
     throw bad_expected_access<E>(this->get_error());
   }
   YK_POLYFILL_CXX14_CONSTEXPR T&& value() &&
   {
+    static_assert(std::is_copy_constructible<E>::value && std::is_constructible<E, E&&>::value, "E must be copy constructible and constructible from E&&");
     if (has_value()) return std::move(this->get_value());
     throw bad_expected_access<E>(std::move(this->get_error()));
   }
   YK_POLYFILL_CXX14_CONSTEXPR T const&& value() const&&
   {
+    static_assert(std::is_copy_constructible<E>::value && std::is_constructible<E, E const&&>::value,
+                  "E must be copy constructible and constructible from E const&&");
     if (has_value()) return std::move(this->get_value());
     throw bad_expected_access<E>(std::move(this->get_error()));
   }
@@ -898,7 +903,7 @@ public:
 
   // monadic operations
 
-  template<class F>
+  template<class F, class E2 = E, typename std::enable_if<std::is_constructible<E2, E2&>::value, std::nullptr_t>::type = nullptr>
   YK_POLYFILL_CXX14_CONSTEXPR auto and_then(F&& f) & -> typename remove_cvref<typename invoke_result<F, T&>::type>::type
   {
     using U = typename remove_cvref<typename invoke_result<F, T&>::type>::type;
@@ -908,7 +913,7 @@ public:
     return U(unexpect, this->get_error());
   }
 
-  template<class F>
+  template<class F, class E2 = E, typename std::enable_if<std::is_constructible<E2, E2 const&>::value, std::nullptr_t>::type = nullptr>
   YK_POLYFILL_CXX14_CONSTEXPR auto and_then(F&& f) const& -> typename remove_cvref<typename invoke_result<F, T const&>::type>::type
   {
     using U = typename remove_cvref<typename invoke_result<F, T const&>::type>::type;
@@ -918,7 +923,7 @@ public:
     return U(unexpect, this->get_error());
   }
 
-  template<class F>
+  template<class F, class E2 = E, typename std::enable_if<std::is_constructible<E2, E2&&>::value, std::nullptr_t>::type = nullptr>
   YK_POLYFILL_CXX14_CONSTEXPR auto and_then(F&& f) && -> typename remove_cvref<typename invoke_result<F, T&&>::type>::type
   {
     using U = typename remove_cvref<typename invoke_result<F, T&&>::type>::type;
@@ -928,7 +933,7 @@ public:
     return U(unexpect, std::move(this->get_error()));
   }
 
-  template<class F>
+  template<class F, class E2 = E, typename std::enable_if<std::is_constructible<E2, E2 const&&>::value, std::nullptr_t>::type = nullptr>
   YK_POLYFILL_CXX14_CONSTEXPR auto and_then(F&& f) const&& -> typename remove_cvref<typename invoke_result<F, T const&&>::type>::type
   {
     using U = typename remove_cvref<typename invoke_result<F, T const&&>::type>::type;
@@ -938,7 +943,7 @@ public:
     return U(unexpect, std::move(this->get_error()));
   }
 
-  template<class F>
+  template<class F, class T2 = T, typename std::enable_if<std::is_constructible<T2, T2&>::value, std::nullptr_t>::type = nullptr>
   YK_POLYFILL_CXX14_CONSTEXPR auto or_else(F&& f) & -> typename remove_cvref<typename invoke_result<F, E&>::type>::type
   {
     using G = typename remove_cvref<typename invoke_result<F, E&>::type>::type;
@@ -948,7 +953,7 @@ public:
     return polyfill::invoke(std::forward<F>(f), this->get_error());
   }
 
-  template<class F>
+  template<class F, class T2 = T, typename std::enable_if<std::is_constructible<T2, T2 const&>::value, std::nullptr_t>::type = nullptr>
   YK_POLYFILL_CXX14_CONSTEXPR auto or_else(F&& f) const& -> typename remove_cvref<typename invoke_result<F, E const&>::type>::type
   {
     using G = typename remove_cvref<typename invoke_result<F, E const&>::type>::type;
@@ -958,7 +963,7 @@ public:
     return polyfill::invoke(std::forward<F>(f), this->get_error());
   }
 
-  template<class F>
+  template<class F, class T2 = T, typename std::enable_if<std::is_constructible<T2, T2&&>::value, std::nullptr_t>::type = nullptr>
   YK_POLYFILL_CXX14_CONSTEXPR auto or_else(F&& f) && -> typename remove_cvref<typename invoke_result<F, E&&>::type>::type
   {
     using G = typename remove_cvref<typename invoke_result<F, E&&>::type>::type;
@@ -968,7 +973,7 @@ public:
     return polyfill::invoke(std::forward<F>(f), std::move(this->get_error()));
   }
 
-  template<class F>
+  template<class F, class T2 = T, typename std::enable_if<std::is_constructible<T2, T2 const&&>::value, std::nullptr_t>::type = nullptr>
   YK_POLYFILL_CXX14_CONSTEXPR auto or_else(F&& f) const&& -> typename remove_cvref<typename invoke_result<F, E const&&>::type>::type
   {
     using G = typename remove_cvref<typename invoke_result<F, E const&&>::type>::type;
@@ -978,7 +983,7 @@ public:
     return polyfill::invoke(std::forward<F>(f), std::move(this->get_error()));
   }
 
-  template<class F>
+  template<class F, class E2 = E, typename std::enable_if<std::is_constructible<E2, E2&>::value, std::nullptr_t>::type = nullptr>
   YK_POLYFILL_CXX14_CONSTEXPR auto transform(F&& f) & -> expected<typename std::remove_cv<typename invoke_result<F, T&>::type>::type, E>
   {
     using U = typename std::remove_cv<typename invoke_result<F, T&>::type>::type;
@@ -986,7 +991,7 @@ public:
     return expected<U, E>(unexpect, this->get_error());
   }
 
-  template<class F>
+  template<class F, class E2 = E, typename std::enable_if<std::is_constructible<E2, E2 const&>::value, std::nullptr_t>::type = nullptr>
   YK_POLYFILL_CXX14_CONSTEXPR auto transform(F&& f) const& -> expected<typename std::remove_cv<typename invoke_result<F, T const&>::type>::type, E>
   {
     using U = typename std::remove_cv<typename invoke_result<F, T const&>::type>::type;
@@ -994,7 +999,7 @@ public:
     return expected<U, E>(unexpect, this->get_error());
   }
 
-  template<class F>
+  template<class F, class E2 = E, typename std::enable_if<std::is_constructible<E2, E2&&>::value, std::nullptr_t>::type = nullptr>
   YK_POLYFILL_CXX14_CONSTEXPR auto transform(F&& f) && -> expected<typename std::remove_cv<typename invoke_result<F, T&&>::type>::type, E>
   {
     using U = typename std::remove_cv<typename invoke_result<F, T&&>::type>::type;
@@ -1003,7 +1008,7 @@ public:
     return expected<U, E>(unexpect, std::move(this->get_error()));
   }
 
-  template<class F>
+  template<class F, class E2 = E, typename std::enable_if<std::is_constructible<E2, E2 const&&>::value, std::nullptr_t>::type = nullptr>
   YK_POLYFILL_CXX14_CONSTEXPR auto transform(F&& f) const&& -> expected<typename std::remove_cv<typename invoke_result<F, T const&&>::type>::type, E>
   {
     using U = typename std::remove_cv<typename invoke_result<F, T const&&>::type>::type;
@@ -1012,7 +1017,7 @@ public:
     return expected<U, E>(unexpect, std::move(this->get_error()));
   }
 
-  template<class F>
+  template<class F, class T2 = T, typename std::enable_if<std::is_constructible<T2, T2&>::value, std::nullptr_t>::type = nullptr>
   YK_POLYFILL_CXX14_CONSTEXPR auto transform_error(F&& f) & -> expected<T, typename std::remove_cv<typename invoke_result<F, E&>::type>::type>
   {
     using G = typename std::remove_cv<typename invoke_result<F, E&>::type>::type;
@@ -1020,7 +1025,7 @@ public:
     return expected<T, G>(unexpect, polyfill::invoke(std::forward<F>(f), this->get_error()));
   }
 
-  template<class F>
+  template<class F, class T2 = T, typename std::enable_if<std::is_constructible<T2, T2 const&>::value, std::nullptr_t>::type = nullptr>
   YK_POLYFILL_CXX14_CONSTEXPR auto transform_error(F&& f) const& -> expected<T, typename std::remove_cv<typename invoke_result<F, E const&>::type>::type>
   {
     using G = typename std::remove_cv<typename invoke_result<F, E const&>::type>::type;
@@ -1028,7 +1033,7 @@ public:
     return expected<T, G>(unexpect, polyfill::invoke(std::forward<F>(f), this->get_error()));
   }
 
-  template<class F>
+  template<class F, class T2 = T, typename std::enable_if<std::is_constructible<T2, T2&&>::value, std::nullptr_t>::type = nullptr>
   YK_POLYFILL_CXX14_CONSTEXPR auto transform_error(F&& f) && -> expected<T, typename std::remove_cv<typename invoke_result<F, E&&>::type>::type>
   {
     using G = typename std::remove_cv<typename invoke_result<F, E&&>::type>::type;
@@ -1036,7 +1041,7 @@ public:
     return expected<T, G>(unexpect, polyfill::invoke(std::forward<F>(f), std::move(this->get_error())));
   }
 
-  template<class F>
+  template<class F, class T2 = T, typename std::enable_if<std::is_constructible<T2, T2 const&&>::value, std::nullptr_t>::type = nullptr>
   YK_POLYFILL_CXX14_CONSTEXPR auto transform_error(F&& f) const&& -> expected<T, typename std::remove_cv<typename invoke_result<F, E const&&>::type>::type>
   {
     using G = typename std::remove_cv<typename invoke_result<F, E const&&>::type>::type;
@@ -1082,341 +1087,38 @@ private:
 };
 
 //
-// expected<void, E>
+// expected<cv void, E> [expected.void]
 //
+// The standard defines one partial specialization constrained by is_void_v<T>; without C++20
+// constraints, stamp it out once per cv-qualification of void via expected_void.ipp.
 
-template<class E>
-class expected<void, E> : private detail::cond_trivial_smf<detail::expected_void_storage_base<E>, E> {
-private:
-  using base_type = detail::cond_trivial_smf<detail::expected_void_storage_base<E>, E>;
+}  // namespace polyfill
 
-  static_assert(std::is_object<E>::value && !std::is_array<E>::value && !std::is_const<E>::value && !std::is_volatile<E>::value,
-                "E must be a valid unexpected type");
+}  // namespace yk
 
-public:
-  using value_type = void;
-  using error_type = E;
-  using unexpected_type = unexpected<E>;
+#define YK_POLYFILL_INCLUDE_EXPECTED
 
-  template<class U>
-  using rebind = expected<U, error_type>;
+#define YK_POLYFILL_EXPECTED_VOID_CV
+#include <yk/polyfill/bits/expected_void.ipp>
+#undef YK_POLYFILL_EXPECTED_VOID_CV
 
-  constexpr expected() noexcept : base_type(in_place) {}
+#define YK_POLYFILL_EXPECTED_VOID_CV const
+#include <yk/polyfill/bits/expected_void.ipp>
+#undef YK_POLYFILL_EXPECTED_VOID_CV
 
-  // copy/move constructors are implicit (provided by cond_trivial_smf base)
+#define YK_POLYFILL_EXPECTED_VOID_CV volatile
+#include <yk/polyfill/bits/expected_void.ipp>
+#undef YK_POLYFILL_EXPECTED_VOID_CV
 
-  template<
-      class U, class G,
-      typename std::enable_if<std::is_void<U>::value && detail::expected_void_can_convert<E, G, G const&>::value && std::is_convertible<G const&, E>::value,
-                              std::nullptr_t>::type = nullptr>
-  YK_POLYFILL_CXX20_CONSTEXPR expected(expected<U, G> const& rhs) noexcept(std::is_nothrow_constructible<E, G const&>::value) : base_type()
-  {
-    if (!rhs.has_value()) {
-      this->construct_error(rhs.error());
-    }
-  }
+#define YK_POLYFILL_EXPECTED_VOID_CV const volatile
+#include <yk/polyfill/bits/expected_void.ipp>
+#undef YK_POLYFILL_EXPECTED_VOID_CV
 
-  template<
-      class U, class G,
-      typename std::enable_if<std::is_void<U>::value && detail::expected_void_can_convert<E, G, G const&>::value && !std::is_convertible<G const&, E>::value,
-                              std::nullptr_t>::type = nullptr>
-  YK_POLYFILL_CXX20_CONSTEXPR explicit expected(expected<U, G> const& rhs) noexcept(std::is_nothrow_constructible<E, G const&>::value) : base_type()
-  {
-    if (!rhs.has_value()) {
-      this->construct_error(rhs.error());
-    }
-  }
+#undef YK_POLYFILL_INCLUDE_EXPECTED
 
-  template<class U, class G,
-           typename std::enable_if<std::is_void<U>::value && detail::expected_void_can_convert<E, G, G>::value && std::is_convertible<G, E>::value,
-                                   std::nullptr_t>::type = nullptr>
-  YK_POLYFILL_CXX20_CONSTEXPR expected(expected<U, G>&& rhs) noexcept(std::is_nothrow_constructible<E, G>::value) : base_type()
-  {
-    if (!rhs.has_value()) {
-      this->construct_error(std::move(rhs).error());
-    }
-  }
+namespace yk {
 
-  template<class U, class G,
-           typename std::enable_if<std::is_void<U>::value && detail::expected_void_can_convert<E, G, G>::value && !std::is_convertible<G, E>::value,
-                                   std::nullptr_t>::type = nullptr>
-  YK_POLYFILL_CXX20_CONSTEXPR explicit expected(expected<U, G>&& rhs) noexcept(std::is_nothrow_constructible<E, G>::value) : base_type()
-  {
-    if (!rhs.has_value()) {
-      this->construct_error(std::move(rhs).error());
-    }
-  }
-
-  template<class G,
-           typename std::enable_if<std::is_constructible<E, G const&>::value && std::is_convertible<G const&, E>::value, std::nullptr_t>::type = nullptr>
-  constexpr expected(unexpected<G> const& e) noexcept(std::is_nothrow_constructible<E, G const&>::value) : base_type(unexpect, e.error())
-  {
-  }
-
-  template<class G,
-           typename std::enable_if<std::is_constructible<E, G const&>::value && !std::is_convertible<G const&, E>::value, std::nullptr_t>::type = nullptr>
-  constexpr explicit expected(unexpected<G> const& e) noexcept(std::is_nothrow_constructible<E, G const&>::value) : base_type(unexpect, e.error())
-  {
-  }
-
-  template<class G, typename std::enable_if<std::is_constructible<E, G>::value && std::is_convertible<G, E>::value, std::nullptr_t>::type = nullptr>
-  constexpr expected(unexpected<G>&& e) noexcept(std::is_nothrow_constructible<E, G>::value) : base_type(unexpect, std::move(e).error())
-  {
-  }
-
-  template<class G, typename std::enable_if<std::is_constructible<E, G>::value && !std::is_convertible<G, E>::value, std::nullptr_t>::type = nullptr>
-  constexpr explicit expected(unexpected<G>&& e) noexcept(std::is_nothrow_constructible<E, G>::value) : base_type(unexpect, std::move(e).error())
-  {
-  }
-
-  constexpr explicit expected(in_place_t) noexcept : base_type(in_place) {}
-
-  template<class... Args, typename std::enable_if<std::is_constructible<E, Args...>::value, std::nullptr_t>::type = nullptr>
-  constexpr explicit expected(unexpect_t, Args&&... args) noexcept(std::is_nothrow_constructible<E, Args...>::value)
-      : base_type(unexpect, std::forward<Args>(args)...)
-  {
-  }
-
-  template<class U, class... Args, typename std::enable_if<std::is_constructible<E, std::initializer_list<U>&, Args...>::value, std::nullptr_t>::type = nullptr>
-  constexpr explicit expected(unexpect_t, std::initializer_list<U> il, Args&&... args)
-      noexcept(std::is_nothrow_constructible<E, std::initializer_list<U>&, Args...>::value)
-      : base_type(unexpect, il, std::forward<Args>(args)...)
-  {
-  }
-
-  // assignment (copy/move assignment are implicit)
-
-  template<class G,
-           typename std::enable_if<std::is_constructible<E, G const&>::value && std::is_assignable<E&, G const&>::value, std::nullptr_t>::type = nullptr>
-  YK_POLYFILL_CXX20_CONSTEXPR expected& operator=(unexpected<G> const& e)
-  {
-    if (has_value()) {
-      this->construct_error(e.error());
-    } else {
-      this->get_error() = e.error();
-    }
-    return *this;
-  }
-
-  template<class G, typename std::enable_if<std::is_constructible<E, G>::value && std::is_assignable<E&, G>::value, std::nullptr_t>::type = nullptr>
-  YK_POLYFILL_CXX20_CONSTEXPR expected& operator=(unexpected<G>&& e)
-  {
-    if (has_value()) {
-      this->construct_error(std::move(e).error());
-    } else {
-      this->get_error() = std::move(e).error();
-    }
-    return *this;
-  }
-
-  YK_POLYFILL_CXX20_CONSTEXPR void emplace() noexcept { this->destroy(); }
-
-  // [expected.void.swap]
-  template<class E2 = E,
-           typename std::enable_if<is_swappable<E2>::value && std::is_move_constructible<E2>::value, std::nullptr_t>::type = nullptr>
-  YK_POLYFILL_CXX20_CONSTEXPR void swap(expected& rhs) noexcept(std::is_nothrow_move_constructible<E>::value && is_nothrow_swappable<E>::value)
-  {
-    if (rhs.has_value()) {
-      if (!has_value()) {
-        rhs.construct_error(std::move(this->get_error()));
-        this->destroy();
-      }
-    } else {
-      if (has_value()) {
-        this->construct_error(std::move(rhs.get_error()));
-        rhs.destroy();
-      } else {
-        using std::swap;
-        swap(this->get_error(), rhs.get_error());
-      }
-    }
-  }
-
-  // observers
-
-  YK_POLYFILL_NODISCARD constexpr explicit operator bool() const noexcept { return has_value(); }
-  YK_POLYFILL_NODISCARD constexpr bool has_value() const noexcept { return base_type::has_value(); }
-
-  YK_POLYFILL_CXX14_CONSTEXPR void operator*() const noexcept {}
-
-  YK_POLYFILL_CXX14_CONSTEXPR void value() const&
-  {
-    if (!has_value()) throw bad_expected_access<E>(this->get_error());
-  }
-  YK_POLYFILL_CXX14_CONSTEXPR void value() &&
-  {
-    if (!has_value()) throw bad_expected_access<E>(std::move(this->get_error()));
-  }
-
-  YK_POLYFILL_NODISCARD constexpr E const& error() const& noexcept { return this->get_error(); }
-  YK_POLYFILL_NODISCARD YK_POLYFILL_CXX14_CONSTEXPR E& error() & noexcept { return this->get_error(); }
-  YK_POLYFILL_NODISCARD constexpr E const&& error() const&& noexcept { return std::move(*this).base_get_error(); }
-  YK_POLYFILL_NODISCARD YK_POLYFILL_CXX14_CONSTEXPR E&& error() && noexcept { return std::move(*this).base_get_error(); }
-
-  template<class G = E>
-  YK_POLYFILL_CXX14_CONSTEXPR E error_or(G&& e) const&
-  {
-    static_assert(std::is_copy_constructible<E>::value && std::is_convertible<G, E>::value, "E must be copy constructible and the argument convertible to E");
-    return has_value() ? static_cast<E>(std::forward<G>(e)) : this->get_error();
-  }
-
-  template<class G = E>
-  YK_POLYFILL_CXX14_CONSTEXPR E error_or(G&& e) &&
-  {
-    static_assert(std::is_move_constructible<E>::value && std::is_convertible<G, E>::value, "E must be move constructible and the argument convertible to E");
-    return has_value() ? static_cast<E>(std::forward<G>(e)) : std::move(this->get_error());
-  }
-
-  // monadic operations
-
-  template<class F>
-  YK_POLYFILL_CXX14_CONSTEXPR auto and_then(F&& f) & -> typename remove_cvref<typename invoke_result<F>::type>::type
-  {
-    using U = typename remove_cvref<typename invoke_result<F>::type>::type;
-    static_assert(detail::is_expected<U>::value, "result of F must be a specialization of expected");
-    static_assert(std::is_same<typename U::error_type, E>::value, "F's expected result must have the same error_type");
-    if (has_value()) return polyfill::invoke(std::forward<F>(f));
-    return U(unexpect, this->get_error());
-  }
-
-  template<class F>
-  YK_POLYFILL_CXX14_CONSTEXPR auto and_then(F&& f) const& -> typename remove_cvref<typename invoke_result<F>::type>::type
-  {
-    using U = typename remove_cvref<typename invoke_result<F>::type>::type;
-    static_assert(detail::is_expected<U>::value, "result of F must be a specialization of expected");
-    static_assert(std::is_same<typename U::error_type, E>::value, "F's expected result must have the same error_type");
-    if (has_value()) return polyfill::invoke(std::forward<F>(f));
-    return U(unexpect, this->get_error());
-  }
-
-  template<class F>
-  YK_POLYFILL_CXX14_CONSTEXPR auto and_then(F&& f) && -> typename remove_cvref<typename invoke_result<F>::type>::type
-  {
-    using U = typename remove_cvref<typename invoke_result<F>::type>::type;
-    static_assert(detail::is_expected<U>::value, "result of F must be a specialization of expected");
-    static_assert(std::is_same<typename U::error_type, E>::value, "F's expected result must have the same error_type");
-    if (has_value()) return polyfill::invoke(std::forward<F>(f));
-    return U(unexpect, std::move(this->get_error()));
-  }
-
-  template<class F>
-  YK_POLYFILL_CXX14_CONSTEXPR auto and_then(F&& f) const&& -> typename remove_cvref<typename invoke_result<F>::type>::type
-  {
-    using U = typename remove_cvref<typename invoke_result<F>::type>::type;
-    static_assert(detail::is_expected<U>::value, "result of F must be a specialization of expected");
-    static_assert(std::is_same<typename U::error_type, E>::value, "F's expected result must have the same error_type");
-    if (has_value()) return polyfill::invoke(std::forward<F>(f));
-    return U(unexpect, std::move(this->get_error()));
-  }
-
-  template<class F>
-  YK_POLYFILL_CXX14_CONSTEXPR auto or_else(F&& f) & -> typename remove_cvref<typename invoke_result<F, E&>::type>::type
-  {
-    using G = typename remove_cvref<typename invoke_result<F, E&>::type>::type;
-    static_assert(detail::is_expected<G>::value, "result of F must be a specialization of expected");
-    static_assert(std::is_void<typename G::value_type>::value, "F's expected result must have void value_type");
-    if (has_value()) return G();
-    return polyfill::invoke(std::forward<F>(f), this->get_error());
-  }
-
-  template<class F>
-  YK_POLYFILL_CXX14_CONSTEXPR auto or_else(F&& f) const& -> typename remove_cvref<typename invoke_result<F, E const&>::type>::type
-  {
-    using G = typename remove_cvref<typename invoke_result<F, E const&>::type>::type;
-    static_assert(detail::is_expected<G>::value, "result of F must be a specialization of expected");
-    static_assert(std::is_void<typename G::value_type>::value, "F's expected result must have void value_type");
-    if (has_value()) return G();
-    return polyfill::invoke(std::forward<F>(f), this->get_error());
-  }
-
-  template<class F>
-  YK_POLYFILL_CXX14_CONSTEXPR auto or_else(F&& f) && -> typename remove_cvref<typename invoke_result<F, E&&>::type>::type
-  {
-    using G = typename remove_cvref<typename invoke_result<F, E&&>::type>::type;
-    static_assert(detail::is_expected<G>::value, "result of F must be a specialization of expected");
-    static_assert(std::is_void<typename G::value_type>::value, "F's expected result must have void value_type");
-    if (has_value()) return G();
-    return polyfill::invoke(std::forward<F>(f), std::move(this->get_error()));
-  }
-
-  template<class F>
-  YK_POLYFILL_CXX14_CONSTEXPR auto or_else(F&& f) const&& -> typename remove_cvref<typename invoke_result<F, E const&&>::type>::type
-  {
-    using G = typename remove_cvref<typename invoke_result<F, E const&&>::type>::type;
-    static_assert(detail::is_expected<G>::value, "result of F must be a specialization of expected");
-    static_assert(std::is_void<typename G::value_type>::value, "F's expected result must have void value_type");
-    if (has_value()) return G();
-    return polyfill::invoke(std::forward<F>(f), std::move(this->get_error()));
-  }
-
-  template<class F>
-  YK_POLYFILL_CXX14_CONSTEXPR auto transform(F&& f) & -> expected<typename std::remove_cv<typename invoke_result<F>::type>::type, E>
-  {
-    using U = typename std::remove_cv<typename invoke_result<F>::type>::type;
-    if (has_value()) return detail::expected_transform_make<expected<U, E>>(bool_constant<std::is_void<U>::value>{}, std::forward<F>(f));
-    return expected<U, E>(unexpect, this->get_error());
-  }
-
-  template<class F>
-  YK_POLYFILL_CXX14_CONSTEXPR auto transform(F&& f) const& -> expected<typename std::remove_cv<typename invoke_result<F>::type>::type, E>
-  {
-    using U = typename std::remove_cv<typename invoke_result<F>::type>::type;
-    if (has_value()) return detail::expected_transform_make<expected<U, E>>(bool_constant<std::is_void<U>::value>{}, std::forward<F>(f));
-    return expected<U, E>(unexpect, this->get_error());
-  }
-
-  template<class F>
-  YK_POLYFILL_CXX14_CONSTEXPR auto transform(F&& f) && -> expected<typename std::remove_cv<typename invoke_result<F>::type>::type, E>
-  {
-    using U = typename std::remove_cv<typename invoke_result<F>::type>::type;
-    if (has_value()) return detail::expected_transform_make<expected<U, E>>(bool_constant<std::is_void<U>::value>{}, std::forward<F>(f));
-    return expected<U, E>(unexpect, std::move(this->get_error()));
-  }
-
-  template<class F>
-  YK_POLYFILL_CXX14_CONSTEXPR auto transform(F&& f) const&& -> expected<typename std::remove_cv<typename invoke_result<F>::type>::type, E>
-  {
-    using U = typename std::remove_cv<typename invoke_result<F>::type>::type;
-    if (has_value()) return detail::expected_transform_make<expected<U, E>>(bool_constant<std::is_void<U>::value>{}, std::forward<F>(f));
-    return expected<U, E>(unexpect, std::move(this->get_error()));
-  }
-
-  template<class F>
-  YK_POLYFILL_CXX14_CONSTEXPR auto transform_error(F&& f) & -> expected<void, typename std::remove_cv<typename invoke_result<F, E&>::type>::type>
-  {
-    using G = typename std::remove_cv<typename invoke_result<F, E&>::type>::type;
-    if (has_value()) return expected<void, G>();
-    return expected<void, G>(unexpect, polyfill::invoke(std::forward<F>(f), this->get_error()));
-  }
-
-  template<class F>
-  YK_POLYFILL_CXX14_CONSTEXPR auto transform_error(F&& f) const& -> expected<void, typename std::remove_cv<typename invoke_result<F, E const&>::type>::type>
-  {
-    using G = typename std::remove_cv<typename invoke_result<F, E const&>::type>::type;
-    if (has_value()) return expected<void, G>();
-    return expected<void, G>(unexpect, polyfill::invoke(std::forward<F>(f), this->get_error()));
-  }
-
-  template<class F>
-  YK_POLYFILL_CXX14_CONSTEXPR auto transform_error(F&& f) && -> expected<void, typename std::remove_cv<typename invoke_result<F, E&&>::type>::type>
-  {
-    using G = typename std::remove_cv<typename invoke_result<F, E&&>::type>::type;
-    if (has_value()) return expected<void, G>();
-    return expected<void, G>(unexpect, polyfill::invoke(std::forward<F>(f), std::move(this->get_error())));
-  }
-
-  template<class F>
-  YK_POLYFILL_CXX14_CONSTEXPR auto transform_error(F&& f) const&& -> expected<void, typename std::remove_cv<typename invoke_result<F, E const&&>::type>::type>
-  {
-    using G = typename std::remove_cv<typename invoke_result<F, E const&&>::type>::type;
-    if (has_value()) return expected<void, G>();
-    return expected<void, G>(unexpect, polyfill::invoke(std::forward<F>(f), std::move(this->get_error())));
-  }
-
-private:
-  YK_POLYFILL_CXX14_CONSTEXPR E&& base_get_error() && noexcept { return static_cast<base_type&&>(*this).get_error(); }
-  constexpr E const&& base_get_error() const&& noexcept { return static_cast<base_type const&&>(*this).get_error(); }
-};
+namespace polyfill {
 
 // comparisons
 //
@@ -1437,10 +1139,12 @@ operator==(expected<T1, E1> const& lhs, expected<T2, E2> const& rhs)
   return static_cast<bool>(lhs.error() == rhs.error());
 }
 
-template<class E1, class E2>
+template<class T1, class E1, class T2, class E2>
 YK_POLYFILL_CXX14_CONSTEXPR
-    typename std::enable_if<std::is_convertible<decltype(std::declval<E1 const&>() == std::declval<E2 const&>()), bool>::value, bool>::type
-    operator==(expected<void, E1> const& lhs, expected<void, E2> const& rhs)
+    typename std::enable_if<std::is_void<T1>::value && std::is_void<T2>::value
+                                && std::is_convertible<decltype(std::declval<E1 const&>() == std::declval<E2 const&>()), bool>::value,
+                            bool>::type
+    operator==(expected<T1, E1> const& lhs, expected<T2, E2> const& rhs)
 {
   if (lhs.has_value() != rhs.has_value()) return false;
   if (lhs.has_value()) return true;
@@ -1475,10 +1179,12 @@ YK_POLYFILL_CXX14_CONSTEXPR typename std::enable_if<!std::is_void<T1>::value && 
   return !(lhs == rhs);
 }
 
-template<class E1, class E2>
+template<class T1, class E1, class T2, class E2>
 YK_POLYFILL_CXX14_CONSTEXPR
-    typename std::enable_if<std::is_convertible<decltype(std::declval<E1 const&>() == std::declval<E2 const&>()), bool>::value, bool>::type
-    operator!=(expected<void, E1> const& lhs, expected<void, E2> const& rhs)
+    typename std::enable_if<std::is_void<T1>::value && std::is_void<T2>::value
+                                && std::is_convertible<decltype(std::declval<E1 const&>() == std::declval<E2 const&>()), bool>::value,
+                            bool>::type
+    operator!=(expected<T1, E1> const& lhs, expected<T2, E2> const& rhs)
 {
   return !(lhs == rhs);
 }

--- a/include/yk/polyfill/expected.hpp
+++ b/include/yk/polyfill/expected.hpp
@@ -846,7 +846,8 @@ public:
   {
     static_assert(std::is_copy_constructible<E>::value, "E must be copy constructible");
     if (has_value()) return this->get_value();
-    throw bad_expected_access<E>(this->get_error());
+    // [expected.object.obs]: throws bad_expected_access(as_const(error()))
+    throw bad_expected_access<E>(static_cast<E const&>(this->get_error()));
   }
   YK_POLYFILL_CXX14_CONSTEXPR T const& value() const&
   {

--- a/include/yk/polyfill/expected.hpp
+++ b/include/yk/polyfill/expected.hpp
@@ -62,10 +62,10 @@ public:
 
   char const* what() const noexcept override { return "bad access to expected without expected value"; }
 
-  [[nodiscard]] E& error() & noexcept { return error_; }
-  [[nodiscard]] E const& error() const& noexcept { return error_; }
-  [[nodiscard]] E&& error() && noexcept { return std::move(error_); }
-  [[nodiscard]] E const&& error() const&& noexcept { return std::move(error_); }
+  YK_POLYFILL_NODISCARD E& error() & noexcept { return error_; }
+  YK_POLYFILL_NODISCARD E const& error() const& noexcept { return error_; }
+  YK_POLYFILL_NODISCARD E&& error() && noexcept { return std::move(error_); }
+  YK_POLYFILL_NODISCARD E const&& error() const&& noexcept { return std::move(error_); }
 
 private:
   E error_;
@@ -104,10 +104,10 @@ public:
   {
   }
 
-  [[nodiscard]] constexpr E const& error() const& noexcept { return error_; }
-  [[nodiscard]] YK_POLYFILL_CXX14_CONSTEXPR E& error() & noexcept { return error_; }
-  [[nodiscard]] constexpr E const&& error() const&& noexcept { return std::move(error_); }
-  [[nodiscard]] YK_POLYFILL_CXX14_CONSTEXPR E&& error() && noexcept { return std::move(error_); }
+  YK_POLYFILL_NODISCARD constexpr E const& error() const& noexcept { return error_; }
+  YK_POLYFILL_NODISCARD YK_POLYFILL_CXX14_CONSTEXPR E& error() & noexcept { return error_; }
+  YK_POLYFILL_NODISCARD constexpr E const&& error() const&& noexcept { return std::move(error_); }
+  YK_POLYFILL_NODISCARD YK_POLYFILL_CXX14_CONSTEXPR E&& error() && noexcept { return std::move(error_); }
 
   template<class E2 = E, typename std::enable_if<is_swappable<E2>::value, std::nullptr_t>::type = nullptr>
   YK_POLYFILL_CXX14_CONSTEXPR void swap(unexpected& other) noexcept(is_nothrow_swappable<E>::value)
@@ -307,17 +307,17 @@ struct expected_storage_base : expected_destruct_base<T, E> {
   using base = expected_destruct_base<T, E>;
   using base::base;
 
-  [[nodiscard]] constexpr bool has_value() const noexcept { return base::state_ == expected_state::has_value; }
+  YK_POLYFILL_NODISCARD constexpr bool has_value() const noexcept { return base::state_ == expected_state::has_value; }
 
-  [[nodiscard]] YK_POLYFILL_CXX14_CONSTEXPR T& get_value() & noexcept { return base::val_; }
-  [[nodiscard]] constexpr T const& get_value() const& noexcept { return base::val_; }
-  [[nodiscard]] YK_POLYFILL_CXX14_CONSTEXPR T&& get_value() && noexcept { return std::move(base::val_); }
-  [[nodiscard]] constexpr T const&& get_value() const&& noexcept { return std::move(base::val_); }
+  YK_POLYFILL_NODISCARD YK_POLYFILL_CXX14_CONSTEXPR T& get_value() & noexcept { return base::val_; }
+  YK_POLYFILL_NODISCARD constexpr T const& get_value() const& noexcept { return base::val_; }
+  YK_POLYFILL_NODISCARD YK_POLYFILL_CXX14_CONSTEXPR T&& get_value() && noexcept { return std::move(base::val_); }
+  YK_POLYFILL_NODISCARD constexpr T const&& get_value() const&& noexcept { return std::move(base::val_); }
 
-  [[nodiscard]] YK_POLYFILL_CXX14_CONSTEXPR E& get_error() & noexcept { return base::unex_; }
-  [[nodiscard]] constexpr E const& get_error() const& noexcept { return base::unex_; }
-  [[nodiscard]] YK_POLYFILL_CXX14_CONSTEXPR E&& get_error() && noexcept { return std::move(base::unex_); }
-  [[nodiscard]] constexpr E const&& get_error() const&& noexcept { return std::move(base::unex_); }
+  YK_POLYFILL_NODISCARD YK_POLYFILL_CXX14_CONSTEXPR E& get_error() & noexcept { return base::unex_; }
+  YK_POLYFILL_NODISCARD constexpr E const& get_error() const& noexcept { return base::unex_; }
+  YK_POLYFILL_NODISCARD YK_POLYFILL_CXX14_CONSTEXPR E&& get_error() && noexcept { return std::move(base::unex_); }
+  YK_POLYFILL_NODISCARD constexpr E const&& get_error() const&& noexcept { return std::move(base::unex_); }
 
   template<class... Args>
   YK_POLYFILL_CXX20_CONSTEXPR void construct_value(Args&&... args) noexcept(std::is_nothrow_constructible<T, Args...>::value)
@@ -466,12 +466,12 @@ struct expected_void_storage_base : expected_void_destruct_base<E> {
   using base = expected_void_destruct_base<E>;
   using base::base;
 
-  [[nodiscard]] constexpr bool has_value() const noexcept { return base::has_val_; }
+  YK_POLYFILL_NODISCARD constexpr bool has_value() const noexcept { return base::has_val_; }
 
-  [[nodiscard]] YK_POLYFILL_CXX14_CONSTEXPR E& get_error() & noexcept { return base::unex_; }
-  [[nodiscard]] constexpr E const& get_error() const& noexcept { return base::unex_; }
-  [[nodiscard]] YK_POLYFILL_CXX14_CONSTEXPR E&& get_error() && noexcept { return std::move(base::unex_); }
-  [[nodiscard]] constexpr E const&& get_error() const&& noexcept { return std::move(base::unex_); }
+  YK_POLYFILL_NODISCARD YK_POLYFILL_CXX14_CONSTEXPR E& get_error() & noexcept { return base::unex_; }
+  YK_POLYFILL_NODISCARD constexpr E const& get_error() const& noexcept { return base::unex_; }
+  YK_POLYFILL_NODISCARD YK_POLYFILL_CXX14_CONSTEXPR E&& get_error() && noexcept { return std::move(base::unex_); }
+  YK_POLYFILL_NODISCARD constexpr E const&& get_error() const&& noexcept { return std::move(base::unex_); }
 
   YK_POLYFILL_CXX20_CONSTEXPR void construct_valueless_value() noexcept { base::has_val_ = true; }
 
@@ -825,16 +825,16 @@ public:
 
   // observers
 
-  [[nodiscard]] YK_POLYFILL_CXX14_CONSTEXPR T const* operator->() const noexcept { return std::addressof(this->get_value()); }
-  [[nodiscard]] YK_POLYFILL_CXX14_CONSTEXPR T* operator->() noexcept { return std::addressof(this->get_value()); }
+  YK_POLYFILL_NODISCARD YK_POLYFILL_CXX14_CONSTEXPR T const* operator->() const noexcept { return std::addressof(this->get_value()); }
+  YK_POLYFILL_NODISCARD YK_POLYFILL_CXX14_CONSTEXPR T* operator->() noexcept { return std::addressof(this->get_value()); }
 
-  [[nodiscard]] constexpr T const& operator*() const& noexcept { return this->get_value(); }
-  [[nodiscard]] YK_POLYFILL_CXX14_CONSTEXPR T& operator*() & noexcept { return this->get_value(); }
-  [[nodiscard]] constexpr T const&& operator*() const&& noexcept { return std::move(*this).base_get_value(); }
-  [[nodiscard]] YK_POLYFILL_CXX14_CONSTEXPR T&& operator*() && noexcept { return std::move(*this).base_get_value(); }
+  YK_POLYFILL_NODISCARD constexpr T const& operator*() const& noexcept { return this->get_value(); }
+  YK_POLYFILL_NODISCARD YK_POLYFILL_CXX14_CONSTEXPR T& operator*() & noexcept { return this->get_value(); }
+  YK_POLYFILL_NODISCARD constexpr T const&& operator*() const&& noexcept { return std::move(*this).base_get_value(); }
+  YK_POLYFILL_NODISCARD YK_POLYFILL_CXX14_CONSTEXPR T&& operator*() && noexcept { return std::move(*this).base_get_value(); }
 
-  [[nodiscard]] constexpr explicit operator bool() const noexcept { return has_value(); }
-  [[nodiscard]] constexpr bool has_value() const noexcept { return base_type::has_value(); }
+  YK_POLYFILL_NODISCARD constexpr explicit operator bool() const noexcept { return has_value(); }
+  YK_POLYFILL_NODISCARD constexpr bool has_value() const noexcept { return base_type::has_value(); }
 
   YK_POLYFILL_CXX14_CONSTEXPR T& value() &
   {
@@ -857,10 +857,10 @@ public:
     throw bad_expected_access<E>(std::move(this->get_error()));
   }
 
-  [[nodiscard]] constexpr E const& error() const& noexcept { return this->get_error(); }
-  [[nodiscard]] YK_POLYFILL_CXX14_CONSTEXPR E& error() & noexcept { return this->get_error(); }
-  [[nodiscard]] constexpr E const&& error() const&& noexcept { return std::move(*this).base_get_error(); }
-  [[nodiscard]] YK_POLYFILL_CXX14_CONSTEXPR E&& error() && noexcept { return std::move(*this).base_get_error(); }
+  YK_POLYFILL_NODISCARD constexpr E const& error() const& noexcept { return this->get_error(); }
+  YK_POLYFILL_NODISCARD YK_POLYFILL_CXX14_CONSTEXPR E& error() & noexcept { return this->get_error(); }
+  YK_POLYFILL_NODISCARD constexpr E const&& error() const&& noexcept { return std::move(*this).base_get_error(); }
+  YK_POLYFILL_NODISCARD YK_POLYFILL_CXX14_CONSTEXPR E&& error() && noexcept { return std::move(*this).base_get_error(); }
 
   template<class U = typename std::remove_cv<T>::type>
   YK_POLYFILL_CXX14_CONSTEXPR T value_or(U&& v) const&
@@ -1040,10 +1040,10 @@ public:
 
 private:
   // rvalue accessors on the storage (private base), reached through explicit std::move.
-  YK_POLYFILL_CXX14_CONSTEXPR T&& base_get_value() && noexcept { return std::move(static_cast<base_type&>(*this).get_value()); }
-  YK_POLYFILL_CXX14_CONSTEXPR T const&& base_get_value() const&& noexcept { return std::move(static_cast<base_type const&>(*this).get_value()); }
-  YK_POLYFILL_CXX14_CONSTEXPR E&& base_get_error() && noexcept { return std::move(static_cast<base_type&>(*this).get_error()); }
-  YK_POLYFILL_CXX14_CONSTEXPR E const&& base_get_error() const&& noexcept { return std::move(static_cast<base_type const&>(*this).get_error()); }
+  YK_POLYFILL_CXX14_CONSTEXPR T&& base_get_value() && noexcept { return static_cast<base_type&&>(*this).get_value(); }
+  constexpr T const&& base_get_value() const&& noexcept { return static_cast<base_type const&&>(*this).get_value(); }
+  YK_POLYFILL_CXX14_CONSTEXPR E&& base_get_error() && noexcept { return static_cast<base_type&&>(*this).get_error(); }
+  constexpr E const&& base_get_error() const&& noexcept { return static_cast<base_type const&&>(*this).get_error(); }
 
   // this holds a value, rhs holds an error; leave this holding rhs's error and rhs holding this's value.
   YK_POLYFILL_CXX20_CONSTEXPR void swap_value_error(expected& rhs, true_type /* E is nothrow move constructible */)
@@ -1226,8 +1226,8 @@ public:
 
   // observers
 
-  [[nodiscard]] constexpr explicit operator bool() const noexcept { return has_value(); }
-  [[nodiscard]] constexpr bool has_value() const noexcept { return base_type::has_value(); }
+  YK_POLYFILL_NODISCARD constexpr explicit operator bool() const noexcept { return has_value(); }
+  YK_POLYFILL_NODISCARD constexpr bool has_value() const noexcept { return base_type::has_value(); }
 
   YK_POLYFILL_CXX14_CONSTEXPR void operator*() const noexcept {}
 
@@ -1240,10 +1240,10 @@ public:
     if (!has_value()) throw bad_expected_access<E>(std::move(this->get_error()));
   }
 
-  [[nodiscard]] constexpr E const& error() const& noexcept { return this->get_error(); }
-  [[nodiscard]] YK_POLYFILL_CXX14_CONSTEXPR E& error() & noexcept { return this->get_error(); }
-  [[nodiscard]] constexpr E const&& error() const&& noexcept { return std::move(*this).base_get_error(); }
-  [[nodiscard]] YK_POLYFILL_CXX14_CONSTEXPR E&& error() && noexcept { return std::move(*this).base_get_error(); }
+  YK_POLYFILL_NODISCARD constexpr E const& error() const& noexcept { return this->get_error(); }
+  YK_POLYFILL_NODISCARD YK_POLYFILL_CXX14_CONSTEXPR E& error() & noexcept { return this->get_error(); }
+  YK_POLYFILL_NODISCARD constexpr E const&& error() const&& noexcept { return std::move(*this).base_get_error(); }
+  YK_POLYFILL_NODISCARD YK_POLYFILL_CXX14_CONSTEXPR E&& error() && noexcept { return std::move(*this).base_get_error(); }
 
   template<class G = E>
   YK_POLYFILL_CXX14_CONSTEXPR E error_or(G&& e) const&
@@ -1406,8 +1406,8 @@ public:
   }
 
 private:
-  YK_POLYFILL_CXX14_CONSTEXPR E&& base_get_error() && noexcept { return std::move(static_cast<base_type&>(*this).get_error()); }
-  YK_POLYFILL_CXX14_CONSTEXPR E const&& base_get_error() const&& noexcept { return std::move(static_cast<base_type const&>(*this).get_error()); }
+  YK_POLYFILL_CXX14_CONSTEXPR E&& base_get_error() && noexcept { return static_cast<base_type&&>(*this).get_error(); }
+  constexpr E const&& base_get_error() const&& noexcept { return static_cast<base_type const&&>(*this).get_error(); }
 };
 
 // comparisons
@@ -1460,8 +1460,8 @@ YK_POLYFILL_CXX14_CONSTEXPR
 
 template<class T1, class E1, class T2, class E2>
 YK_POLYFILL_CXX14_CONSTEXPR typename std::enable_if<!std::is_void<T1>::value && !std::is_void<T2>::value
-                                                        && std::is_convertible<decltype(std::declval<T1 const&>() != std::declval<T2 const&>()), bool>::value
-                                                        && std::is_convertible<decltype(std::declval<E1 const&>() != std::declval<E2 const&>()), bool>::value,
+                                                        && std::is_convertible<decltype(std::declval<T1 const&>() == std::declval<T2 const&>()), bool>::value
+                                                        && std::is_convertible<decltype(std::declval<E1 const&>() == std::declval<E2 const&>()), bool>::value,
                                                     bool>::type operator!=(expected<T1, E1> const& lhs, expected<T2, E2> const& rhs)
 {
   return !(lhs == rhs);
@@ -1469,7 +1469,7 @@ YK_POLYFILL_CXX14_CONSTEXPR typename std::enable_if<!std::is_void<T1>::value && 
 
 template<class E1, class E2>
 YK_POLYFILL_CXX14_CONSTEXPR
-    typename std::enable_if<std::is_convertible<decltype(std::declval<E1 const&>() != std::declval<E2 const&>()), bool>::value, bool>::type
+    typename std::enable_if<std::is_convertible<decltype(std::declval<E1 const&>() == std::declval<E2 const&>()), bool>::value, bool>::type
     operator!=(expected<void, E1> const& lhs, expected<void, E2> const& rhs)
 {
   return !(lhs == rhs);

--- a/include/yk/polyfill/expected.hpp
+++ b/include/yk/polyfill/expected.hpp
@@ -545,7 +545,10 @@ struct expected_assign_guard<false> {
 
 template<class T, class E, class U, class G, class UF, class GF>
 struct expected_can_convert {
-  static constexpr bool value = std::is_constructible<T, UF>::value && std::is_constructible<E, GF>::value && !converts_from_any_cvref<T, expected<U, G>>::value
+  // [expected.object.cons] applies the converts-from-any-cvref check only "if T is not cv bool";
+  // the unexpected-side check has no such carve-out.
+  static constexpr bool value = std::is_constructible<T, UF>::value && std::is_constructible<E, GF>::value
+                                && (std::is_same<typename std::remove_cv<T>::type, bool>::value || !converts_from_any_cvref<T, expected<U, G>>::value)
                                 && !constructs_from_any_cvref<unexpected<E>, expected<U, G>>::value;
 };
 
@@ -800,12 +803,15 @@ public:
 
   // swap
 
+  // [expected.object.swap]
+  template<class T2 = T, class E2 = E,
+           typename std::enable_if<is_swappable<T2>::value && is_swappable<E2>::value && std::is_move_constructible<T2>::value
+                                       && std::is_move_constructible<E2>::value
+                                       && (std::is_nothrow_move_constructible<T2>::value || std::is_nothrow_move_constructible<E2>::value),
+                                   std::nullptr_t>::type = nullptr>
   YK_POLYFILL_CXX20_CONSTEXPR void swap(expected& rhs) noexcept(std::is_nothrow_move_constructible<T>::value && is_nothrow_swappable<T>::value
                                                                 && std::is_nothrow_move_constructible<E>::value && is_nothrow_swappable<E>::value)
   {
-    static_assert(is_swappable<T>::value && is_swappable<E>::value && std::is_move_constructible<T>::value && std::is_move_constructible<E>::value
-                      && (std::is_nothrow_move_constructible<T>::value || std::is_nothrow_move_constructible<E>::value),
-                  "expected::swap requirements not met");
     if (rhs.has_value()) {
       if (has_value()) {
         using std::swap;
@@ -1205,9 +1211,11 @@ public:
 
   YK_POLYFILL_CXX20_CONSTEXPR void emplace() noexcept { this->destroy(); }
 
+  // [expected.void.swap]
+  template<class E2 = E,
+           typename std::enable_if<is_swappable<E2>::value && std::is_move_constructible<E2>::value, std::nullptr_t>::type = nullptr>
   YK_POLYFILL_CXX20_CONSTEXPR void swap(expected& rhs) noexcept(std::is_nothrow_move_constructible<E>::value && is_nothrow_swappable<E>::value)
   {
-    static_assert(is_swappable<E>::value && std::is_move_constructible<E>::value, "expected<void, E>::swap requirements not met");
     if (rhs.has_value()) {
       if (!has_value()) {
         rhs.construct_error(std::move(this->get_error()));
@@ -1528,8 +1536,13 @@ YK_POLYFILL_CXX14_CONSTEXPR
 
 #endif
 
+// Mirrors the member swap constraints: [expected.void.swap] for void T (E alone),
+// [expected.object.swap] otherwise (both arms, plus the nothrow-move clause).
 template<class T, class E,
-         typename std::enable_if<(std::is_void<T>::value || std::is_move_constructible<T>::value) && std::is_move_constructible<E>::value,
+         typename std::enable_if<is_swappable<E>::value && std::is_move_constructible<E>::value
+                                     && (std::is_void<T>::value
+                                         || (is_swappable<T>::value && std::is_move_constructible<T>::value
+                                             && (std::is_nothrow_move_constructible<T>::value || std::is_nothrow_move_constructible<E>::value))),
                                  std::nullptr_t>::type = nullptr>
 YK_POLYFILL_CXX20_CONSTEXPR void swap(expected<T, E>& lhs, expected<T, E>& rhs) noexcept(noexcept(lhs.swap(rhs)))
 {

--- a/test/cxx11/CMakeLists.txt
+++ b/test/cxx11/CMakeLists.txt
@@ -31,6 +31,7 @@ target_sources(
         indirect.cpp
         polymorphic.cpp
         function_ref.cpp
+        expected.cpp
 )
 
 set_target_properties(yk_polyfill_cxx11_test PROPERTIES CXX_EXTENSIONS OFF)

--- a/test/cxx11/expected.cpp
+++ b/test/cxx11/expected.cpp
@@ -464,6 +464,37 @@ TEST_CASE("expected assignment SMF deletion")
   STATIC_REQUIRE(std::is_copy_assignable<pf::expected<ThrowMove, int>>::value);
 }
 
+TEST_CASE("expected swap constraints")
+{
+  STATIC_REQUIRE(pf::is_swappable<pf::expected<int, std::string>>::value);
+  STATIC_REQUIRE(pf::is_swappable<pf::expected<void, int>>::value);
+
+  // [expected.object.swap] also requires
+  // (is_nothrow_move_constructible<T> || is_nothrow_move_constructible<E>).
+  // Neither arm qualifies here, so swap must drop out rather than hard-error.
+  STATIC_REQUIRE_FALSE(pf::is_swappable<pf::expected<ThrowMove, ThrowMove>>::value);
+
+  // one nothrow-move-constructible arm restores swappability
+  STATIC_REQUIRE(pf::is_swappable<pf::expected<ThrowMove, int>>::value);
+}
+
+TEST_CASE("expected converting construction with bool value type")
+{
+  // [expected.object.cons] applies the converts-from-any-cvref check only "if T is not cv bool",
+  // so expected<bool, E> stays constructible from another expected despite operator bool.
+  STATIC_REQUIRE(std::is_constructible<pf::expected<bool, int>, pf::expected<int, int>>::value);
+
+  pf::expected<int, int> src(pf::in_place, 1);
+  pf::expected<bool, int> dst(src);
+  CHECK(dst.has_value());
+  CHECK(*dst == true);
+
+  pf::expected<int, int> err(pf::unexpect, 4);
+  pf::expected<bool, int> derr(err);
+  CHECK(!derr.has_value());
+  CHECK(derr.error() == 4);
+}
+
 TEST_CASE("expected reinit strong guarantee on throwing arm switch")
 {
   pf::expected<Bomb, int> a(pf::unexpect, 7);

--- a/test/cxx11/expected.cpp
+++ b/test/cxx11/expected.cpp
@@ -46,6 +46,16 @@ struct ThrowMove {
   ThrowMove& operator=(ThrowMove&&) = default;
 };
 
+// Whether polyfill's own free swap participates for T. Qualified, so only that overload is
+// considered: std::swap gained its is_move_constructible/is_move_assignable constraint only in
+// C++17, and MSVC honors that gating, so an unqualified probe cannot observe the constraint
+// below C++17. See test/cxx17/expected.cpp for the end-to-end is_swappable check.
+template<class T, class = void>
+struct has_polyfill_swap : pf::false_type {};
+
+template<class T>
+struct has_polyfill_swap<T, pf::void_t<decltype(pf::swap(std::declval<T&>(), std::declval<T&>()))>> : pf::true_type {};
+
 // throws from copy/move only while armed; move is non-noexcept so reinit uses the backup rung.
 struct Bomb {
   int tag = 0;
@@ -472,9 +482,10 @@ TEST_CASE("expected swap constraints")
   // [expected.object.swap] also requires
   // (is_nothrow_move_constructible<T> || is_nothrow_move_constructible<E>).
   // Neither arm qualifies here, so swap must drop out rather than hard-error.
-  STATIC_REQUIRE_FALSE(pf::is_swappable<pf::expected<ThrowMove, ThrowMove>>::value);
+  STATIC_REQUIRE_FALSE(has_polyfill_swap<pf::expected<ThrowMove, ThrowMove>>::value);
 
   // one nothrow-move-constructible arm restores swappability
+  STATIC_REQUIRE(has_polyfill_swap<pf::expected<ThrowMove, int>>::value);
   STATIC_REQUIRE(pf::is_swappable<pf::expected<ThrowMove, int>>::value);
 }
 

--- a/test/cxx11/expected.cpp
+++ b/test/cxx11/expected.cpp
@@ -489,6 +489,93 @@ TEST_CASE("expected swap constraints")
   STATIC_REQUIRE(pf::is_swappable<pf::expected<ThrowMove, int>>::value);
 }
 
+TEST_CASE("expected with cv-qualified void")
+{
+  // the standard's void specialization is constrained by is_void_v<T>, covering all cv-void
+  STATIC_REQUIRE(std::is_same<pf::expected<void const, int>::value_type, void const>::value);
+  STATIC_REQUIRE(std::is_same<pf::expected<void volatile, int>::value_type, void volatile>::value);
+
+  pf::expected<void const, int> e;
+  CHECK(e.has_value());
+
+  pf::expected<void const, int> u(pf::unexpect, 4);
+  CHECK(!u.has_value());
+  CHECK(u.error() == 4);
+
+  u.emplace();
+  CHECK(u.has_value());
+
+  pf::expected<void const volatile, int> cv = pf::unexpected<int>(7);
+  CHECK(!cv.has_value());
+  CHECK(cv.error() == 7);
+
+  // comparison across differently cv-qualified void
+  pf::expected<void, int> plain;
+  CHECK(plain == e);
+  CHECK(plain != pf::expected<void volatile, int>(pf::unexpect, 1));
+
+  // monadics; or_else requires the same (cv-qualified) value_type
+  auto t = e.transform([]() { return 5; });
+  CHECK(*t == 5);
+  auto o = pf::expected<void const, int>(pf::unexpect, 2).or_else([](int x) { return pf::expected<void const, int>(pf::unexpect, x + 1); });
+  CHECK(o.error() == 3);
+}
+
+namespace {
+
+struct MoveOnlyErr {
+  MoveOnlyErr() = default;
+  MoveOnlyErr(MoveOnlyErr&&) = default;
+  MoveOnlyErr& operator=(MoveOnlyErr&&) = default;
+};
+
+struct AndThenFn {
+  pf::expected<int, MoveOnlyErr> operator()(int) const;
+};
+
+template<class Exp, class F, class = void>
+struct has_lvalue_and_then : pf::false_type {};
+
+template<class Exp, class F>
+struct has_lvalue_and_then<Exp, F, pf::void_t<decltype(std::declval<Exp&>().and_then(std::declval<F>()))>> : pf::true_type {};
+
+}  // namespace
+
+TEST_CASE("expected monadic constraints")
+{
+  // [expected.object.monadic]: and_then &/const& is constrained on is_constructible<E, decltype(error())>,
+  // so with a move-only E the lvalue overload must drop out rather than hard-error.
+  STATIC_REQUIRE_FALSE(has_lvalue_and_then<pf::expected<int, MoveOnlyErr>, AndThenFn>::value);
+
+  struct CopyableFn {
+    pf::expected<int, int> operator()(int) const;
+  };
+  STATIC_REQUIRE(has_lvalue_and_then<pf::expected<int, int>, CopyableFn>::value);
+}
+
+namespace {
+
+struct InitCounter {
+  static int copies;
+  static int moves;
+  InitCounter(std::initializer_list<int>) {}
+  InitCounter(InitCounter const&) { ++copies; }
+  InitCounter(InitCounter&&) { ++moves; }
+};
+int InitCounter::copies = 0;
+int InitCounter::moves = 0;
+
+}  // namespace
+
+TEST_CASE("expected value-forwarding ctor defaults U to remove_cv_t<T>")
+{
+  // with U defaulting to T (= InitCounter const) the temporary would be const and get copied
+  pf::expected<InitCounter const, int> e({1, 2, 3});
+  CHECK(e.has_value());
+  CHECK(InitCounter::moves == 1);
+  CHECK(InitCounter::copies == 0);
+}
+
 TEST_CASE("expected converting construction with bool value type")
 {
   // [expected.object.cons] applies the converts-from-any-cvref check only "if T is not cv bool",

--- a/test/cxx11/expected.cpp
+++ b/test/cxx11/expected.cpp
@@ -1,0 +1,500 @@
+#if YK_POLYFILL_CATCH2_MAJOR_VERSION < 3
+#include <catch2/catch.hpp>
+#else
+#include <catch2/catch_test_macros.hpp>
+#endif
+
+#include <yk/polyfill/expected.hpp>
+#include <yk/polyfill/utility.hpp>
+
+#include <memory>
+#include <stdexcept>
+#include <string>
+#include <type_traits>
+#include <utility>
+
+namespace pf = yk::polyfill;
+
+namespace {
+
+struct NeedExplicit {
+  int value;
+  explicit NeedExplicit(int arg) : value(arg) {}
+};
+
+struct CountedDtor {
+  static int count;
+  ~CountedDtor() { ++count; }
+};
+int CountedDtor::count = 0;
+
+struct FromInt {
+  int v;
+  FromInt(int x) : v(x) {}
+};
+
+int times_two(int x) { return 2 * x; }
+
+// copy/move constructible + assignable, but with a potentially-throwing move constructor.
+struct ThrowMove {
+  int tag = 0;
+  ThrowMove() = default;
+  ThrowMove(int t) : tag(t) {}
+  ThrowMove(ThrowMove const&) = default;
+  ThrowMove(ThrowMove&&) noexcept(false) { throw std::runtime_error("move"); }
+  ThrowMove& operator=(ThrowMove const&) = default;
+  ThrowMove& operator=(ThrowMove&&) = default;
+};
+
+// throws from copy/move only while armed; move is non-noexcept so reinit uses the backup rung.
+struct Bomb {
+  int tag = 0;
+  static bool armed;
+  Bomb() = default;
+  Bomb(int t) : tag(t) {}
+  Bomb(Bomb const& o) : tag(o.tag)
+  {
+    if (armed) throw std::runtime_error("copy");
+  }
+  Bomb(Bomb&& o) noexcept(false) : tag(o.tag)
+  {
+    if (armed) throw std::runtime_error("move");
+  }
+  Bomb& operator=(Bomb const& o) = default;
+};
+bool Bomb::armed = false;
+
+}  // namespace
+
+TEST_CASE("unexpected basics")
+{
+  // construction from value + error() accessors
+  pf::unexpected<int> u(5);
+  CHECK(u.error() == 5);
+
+  pf::unexpected<int> const cu(7);
+  CHECK(cu.error() == 7);
+  STATIC_REQUIRE(std::is_same<decltype(cu.error()), int const&>::value);
+  STATIC_REQUIRE(std::is_same<decltype(pf::unexpected<int>(1).error()), int&&>::value);
+
+  // in_place construction
+  pf::unexpected<std::string> us(pf::in_place, 3u, 'a');
+  CHECK(us.error() == "aaa");
+
+  // equality
+  CHECK(pf::unexpected<int>(3) == pf::unexpected<int>(3));
+  CHECK(pf::unexpected<int>(3) != pf::unexpected<long>(4));
+
+  // swap
+  pf::unexpected<int> a(1), b(2);
+  a.swap(b);
+  CHECK(a.error() == 2);
+  CHECK(b.error() == 1);
+  swap(a, b);
+  CHECK(a.error() == 1);
+  CHECK(b.error() == 2);
+}
+
+TEST_CASE("expected triviality")
+{
+  STATIC_REQUIRE(std::is_trivially_copy_constructible<pf::expected<int, int>>::value);
+  STATIC_REQUIRE(std::is_trivially_move_constructible<pf::expected<int, int>>::value);
+  STATIC_REQUIRE(std::is_trivially_copy_assignable<pf::expected<int, int>>::value);
+  STATIC_REQUIRE(std::is_trivially_move_assignable<pf::expected<int, int>>::value);
+  STATIC_REQUIRE(std::is_trivially_destructible<pf::expected<int, int>>::value);
+
+  STATIC_REQUIRE(std::is_trivially_copy_constructible<pf::expected<void, int>>::value);
+  STATIC_REQUIRE(std::is_trivially_destructible<pf::expected<void, int>>::value);
+
+  STATIC_REQUIRE_FALSE(std::is_trivially_destructible<pf::expected<std::string, int>>::value);
+  STATIC_REQUIRE_FALSE(std::is_trivially_destructible<pf::expected<int, std::string>>::value);
+}
+
+TEST_CASE("expected member types")
+{
+  STATIC_REQUIRE(std::is_same<pf::expected<int, long>::value_type, int>::value);
+  STATIC_REQUIRE(std::is_same<pf::expected<int, long>::error_type, long>::value);
+  STATIC_REQUIRE(std::is_same<pf::expected<int, long>::unexpected_type, pf::unexpected<long>>::value);
+  STATIC_REQUIRE(std::is_same<pf::expected<int, long>::rebind<char>, pf::expected<char, long>>::value);
+  STATIC_REQUIRE(std::is_same<pf::expected<void, long>::value_type, void>::value);
+}
+
+TEST_CASE("expected construction")
+{
+  // default (value-initialized T)
+  {
+    pf::expected<int, std::string> e;
+    CHECK(e.has_value());
+    CHECK(*e == 0);
+  }
+
+  // in_place
+  {
+    pf::expected<int, std::string> e(pf::in_place, 42);
+    CHECK(e.has_value());
+    CHECK(*e == 42);
+  }
+
+  // unexpect
+  {
+    pf::expected<int, std::string> e(pf::unexpect, 3u, 'z');
+    CHECK(!e.has_value());
+    CHECK(e.error() == "zzz");
+  }
+
+  // value forwarding
+  {
+    pf::expected<int, std::string> e = 7;
+    CHECK(e.has_value());
+    CHECK(*e == 7);
+  }
+
+  // from unexpected
+  {
+    pf::expected<int, std::string> e = pf::unexpected<std::string>("boom");
+    CHECK(!e.has_value());
+    CHECK(e.error() == "boom");
+  }
+
+  // explicit value conversion
+  {
+    pf::expected<NeedExplicit, int> e(pf::in_place, 3);
+    CHECK(e.has_value());
+    CHECK(e->value == 3);
+    STATIC_REQUIRE_FALSE(std::is_convertible<int, pf::expected<NeedExplicit, int>>::value);
+    STATIC_REQUIRE(std::is_constructible<pf::expected<NeedExplicit, int>, int>::value);
+  }
+}
+
+TEST_CASE("expected converting construction")
+{
+  // expected<U,G> const& -> expected<T,E>
+  {
+    pf::expected<int, int> src(pf::in_place, 5);
+    pf::expected<long, long> dst(src);
+    CHECK(dst.has_value());
+    CHECK(*dst == 5);
+  }
+  {
+    pf::expected<int, int> src(pf::unexpect, 9);
+    pf::expected<long, long> dst(src);
+    CHECK(!dst.has_value());
+    CHECK(dst.error() == 9);
+  }
+  // move
+  {
+    pf::expected<FromInt, int> dst(pf::expected<int, int>(pf::in_place, 8));
+    CHECK(dst.has_value());
+    CHECK(dst->v == 8);
+  }
+}
+
+TEST_CASE("expected observers and value()")
+{
+  pf::expected<int, std::string> e(pf::in_place, 10);
+  CHECK(static_cast<bool>(e));
+  CHECK(e.value() == 10);
+  CHECK(*e == 10);
+  CHECK(e.value_or(99) == 10);
+
+  pf::expected<int, std::string> u(pf::unexpect, "err");
+  CHECK(!static_cast<bool>(u));
+  CHECK(u.error() == "err");
+  CHECK(u.value_or(99) == 99);
+  CHECK(u.error_or(std::string("x")) == "err");
+  CHECK(e.error_or(std::string("x")) == "x");
+
+  REQUIRE_THROWS_AS(u.value(), pf::bad_expected_access<std::string>);
+
+  // the thrown exception carries the error
+  bool caught = false;
+  try {
+    u.value();
+  } catch (pf::bad_expected_access<std::string> const& ex) {
+    caught = true;
+    CHECK(ex.error() == "err");
+  }
+  CHECK(caught);
+
+  // base bad_expected_access<void> catch
+  bool caught_base = false;
+  try {
+    u.value();
+  } catch (pf::bad_expected_access<void> const&) {
+    caught_base = true;
+  }
+  CHECK(caught_base);
+}
+
+TEST_CASE("expected assignment")
+{
+  // value = value
+  {
+    pf::expected<int, std::string> e(pf::in_place, 1);
+    e = 2;
+    CHECK(e.has_value());
+    CHECK(*e == 2);
+  }
+  // error -> value (arm switch)
+  {
+    pf::expected<int, std::string> e(pf::unexpect, "e");
+    e = 5;
+    CHECK(e.has_value());
+    CHECK(*e == 5);
+  }
+  // value -> error (arm switch)
+  {
+    pf::expected<int, std::string> e(pf::in_place, 1);
+    e = pf::unexpected<std::string>("bad");
+    CHECK(!e.has_value());
+    CHECK(e.error() == "bad");
+  }
+  // error = error
+  {
+    pf::expected<int, std::string> e(pf::unexpect, "a");
+    e = pf::unexpected<std::string>("b");
+    CHECK(!e.has_value());
+    CHECK(e.error() == "b");
+  }
+  // copy assignment across arms
+  {
+    pf::expected<int, std::string> a(pf::in_place, 1);
+    pf::expected<int, std::string> b(pf::unexpect, "z");
+    a = b;
+    CHECK(!a.has_value());
+    CHECK(a.error() == "z");
+  }
+  // move assignment across arms
+  {
+    pf::expected<std::string, int> a(pf::unexpect, 3);
+    pf::expected<std::string, int> b(pf::in_place, "hello");
+    a = std::move(b);
+    CHECK(a.has_value());
+    CHECK(*a == "hello");
+  }
+}
+
+TEST_CASE("expected emplace")
+{
+  pf::expected<int, std::string> e(pf::unexpect, "e");
+  int& r = e.emplace(77);
+  CHECK(e.has_value());
+  CHECK(*e == 77);
+  CHECK(&r == &*e);
+}
+
+TEST_CASE("expected swap")
+{
+  // value <-> error
+  {
+    pf::expected<int, std::string> a(pf::in_place, 1);
+    pf::expected<int, std::string> b(pf::unexpect, "err");
+    a.swap(b);
+    CHECK(!a.has_value());
+    CHECK(a.error() == "err");
+    CHECK(b.has_value());
+    CHECK(*b == 1);
+  }
+  // value <-> value via free swap
+  {
+    pf::expected<int, std::string> a(pf::in_place, 1);
+    pf::expected<int, std::string> b(pf::in_place, 2);
+    swap(a, b);
+    CHECK(*a == 2);
+    CHECK(*b == 1);
+  }
+  // error <-> error
+  {
+    pf::expected<int, std::string> a(pf::unexpect, "a");
+    pf::expected<int, std::string> b(pf::unexpect, "b");
+    a.swap(b);
+    CHECK(a.error() == "b");
+    CHECK(b.error() == "a");
+  }
+}
+
+TEST_CASE("expected monadic and_then / or_else")
+{
+  pf::expected<int, std::string> e(pf::in_place, 4);
+
+  auto r = e.and_then([](int x) { return pf::expected<int, std::string>(pf::in_place, x + 1); });
+  CHECK(r.has_value());
+  CHECK(*r == 5);
+
+  pf::expected<int, std::string> u(pf::unexpect, "no");
+  auto r2 = u.and_then([](int x) { return pf::expected<int, std::string>(pf::in_place, x + 1); });
+  CHECK(!r2.has_value());
+  CHECK(r2.error() == "no");
+
+  auto r3 = u.or_else([](std::string const& s) { return pf::expected<int, std::string>(pf::in_place, static_cast<int>(s.size())); });
+  CHECK(r3.has_value());
+  CHECK(*r3 == 2);
+
+  auto r4 = e.or_else([](std::string const&) { return pf::expected<int, std::string>(pf::unexpect, "x"); });
+  CHECK(r4.has_value());
+  CHECK(*r4 == 4);
+}
+
+TEST_CASE("expected monadic transform / transform_error")
+{
+  pf::expected<int, std::string> e(pf::in_place, 4);
+
+  auto r = e.transform([](int x) { return x * 10; });
+  STATIC_REQUIRE(std::is_same<decltype(r), pf::expected<int, std::string>>::value);
+  CHECK(r.has_value());
+  CHECK(*r == 40);
+
+  // transform to void
+  auto rv = e.transform([](int) {});
+  STATIC_REQUIRE(std::is_same<decltype(rv), pf::expected<void, std::string>>::value);
+  CHECK(rv.has_value());
+
+  pf::expected<int, std::string> u(pf::unexpect, "oops");
+  auto re = u.transform_error([](std::string const& s) { return static_cast<int>(s.size()); });
+  STATIC_REQUIRE(std::is_same<decltype(re), pf::expected<int, int>>::value);
+  CHECK(!re.has_value());
+  CHECK(re.error() == 4);
+}
+
+TEST_CASE("expected comparisons")
+{
+  pf::expected<int, int> a(pf::in_place, 1);
+  pf::expected<int, int> b(pf::in_place, 1);
+  pf::expected<int, int> c(pf::in_place, 2);
+  pf::expected<int, int> e(pf::unexpect, 9);
+
+  CHECK(a == b);
+  CHECK(a != c);
+  CHECK(a != e);
+  CHECK(a == 1);
+  CHECK(a != 2);
+  CHECK(e == pf::unexpected<int>(9));
+  CHECK(e != pf::unexpected<int>(8));
+  CHECK(1 == a);
+  CHECK(pf::unexpected<int>(9) == e);
+}
+
+TEST_CASE("expected<void, E>")
+{
+  // default
+  {
+    pf::expected<void, int> e;
+    CHECK(e.has_value());
+    CHECK(static_cast<bool>(e));
+    e.value();  // no throw
+  }
+  // in_place
+  {
+    pf::expected<void, int> e(pf::in_place);
+    CHECK(e.has_value());
+  }
+  // unexpect
+  {
+    pf::expected<void, int> e(pf::unexpect, 3);
+    CHECK(!e.has_value());
+    CHECK(e.error() == 3);
+    REQUIRE_THROWS_AS(e.value(), pf::bad_expected_access<int>);
+    CHECK(e.error_or(7) == 3);
+  }
+  // from unexpected
+  {
+    pf::expected<void, int> e = pf::unexpected<int>(5);
+    CHECK(!e.has_value());
+    CHECK(e.error() == 5);
+  }
+  // assignment / emplace
+  {
+    pf::expected<void, int> e(pf::unexpect, 1);
+    e = pf::unexpected<int>(2);
+    CHECK(e.error() == 2);
+    e.emplace();
+    CHECK(e.has_value());
+  }
+  // swap
+  {
+    pf::expected<void, int> a;
+    pf::expected<void, int> b(pf::unexpect, 4);
+    a.swap(b);
+    CHECK(!a.has_value());
+    CHECK(a.error() == 4);
+    CHECK(b.has_value());
+  }
+  // comparisons
+  {
+    pf::expected<void, int> a;
+    pf::expected<void, int> b;
+    pf::expected<void, int> e(pf::unexpect, 1);
+    CHECK(a == b);
+    CHECK(a != e);
+    CHECK(e == pf::unexpected<int>(1));
+  }
+  // monadic
+  {
+    pf::expected<void, int> a;
+    auto r = a.and_then([]() { return pf::expected<int, int>(pf::in_place, 5); });
+    CHECK(r.has_value());
+    CHECK(*r == 5);
+
+    auto t = a.transform([]() { return 42; });
+    STATIC_REQUIRE(std::is_same<decltype(t), pf::expected<int, int>>::value);
+    CHECK(*t == 42);
+
+    pf::expected<void, int> u(pf::unexpect, 8);
+    auto o = u.or_else([](int x) { return pf::expected<void, int>(pf::unexpect, x + 1); });
+    CHECK(!o.has_value());
+    CHECK(o.error() == 9);
+  }
+}
+
+TEST_CASE("expected assignment SMF deletion")
+{
+  // both arms nothrow-move-constructible -> copy/move assignment available
+  STATIC_REQUIRE(std::is_copy_assignable<pf::expected<int, std::string>>::value);
+  STATIC_REQUIRE(std::is_move_assignable<pf::expected<int, std::string>>::value);
+
+  // neither arm is nothrow-move-constructible -> [expected.object.assign] deletes assignment,
+  // beyond what copy/move constructible+assignable alone would allow.
+  STATIC_REQUIRE(std::is_copy_constructible<ThrowMove>::value);
+  STATIC_REQUIRE(std::is_copy_assignable<ThrowMove>::value);
+  STATIC_REQUIRE_FALSE(std::is_nothrow_move_constructible<ThrowMove>::value);
+  STATIC_REQUIRE_FALSE(std::is_copy_assignable<pf::expected<ThrowMove, ThrowMove>>::value);
+  STATIC_REQUIRE_FALSE(std::is_move_assignable<pf::expected<ThrowMove, ThrowMove>>::value);
+
+  // but if one arm is nothrow-move-constructible, assignment is restored
+  STATIC_REQUIRE(std::is_copy_assignable<pf::expected<ThrowMove, int>>::value);
+}
+
+TEST_CASE("expected reinit strong guarantee on throwing arm switch")
+{
+  pf::expected<Bomb, int> a(pf::unexpect, 7);
+  pf::expected<Bomb, int> b(pf::in_place, Bomb(5));
+
+  Bomb::armed = true;
+  bool threw = false;
+  try {
+    a = b;  // switch error -> value; the value copy throws, old error must be restored
+  } catch (std::runtime_error const&) {
+    threw = true;
+  }
+  Bomb::armed = false;
+
+  CHECK(threw);
+  CHECK(!a.has_value());
+  CHECK(a.error() == 7);
+}
+
+TEST_CASE("expected move-only value")
+{
+  pf::expected<std::unique_ptr<int>, int> e(pf::in_place, new int(5));
+  CHECK(e.has_value());
+  CHECK(*e.value() == 5);
+
+  pf::expected<std::unique_ptr<int>, int> moved(std::move(e));
+  CHECK(moved.has_value());
+  CHECK(*moved.value() == 5);
+
+  pf::expected<std::unique_ptr<int>, int> err(pf::unexpect, 9);
+  moved = std::move(err);
+  CHECK(!moved.has_value());
+  CHECK(moved.error() == 9);
+}

--- a/test/cxx11/expected.cpp
+++ b/test/cxx11/expected.cpp
@@ -498,3 +498,134 @@ TEST_CASE("expected move-only value")
   CHECK(!moved.has_value());
   CHECK(moved.error() == 9);
 }
+
+TEST_CASE("expected rvalue observers")
+{
+  // value() rvalue overloads
+  {
+    pf::expected<std::string, int> e(pf::in_place, "hello");
+    STATIC_REQUIRE(std::is_same<decltype(std::move(e).value()), std::string&&>::value);
+    std::string s = std::move(e).value();
+    CHECK(s == "hello");
+  }
+  {
+    pf::expected<std::string, int> const e(pf::in_place, "world");
+    STATIC_REQUIRE(std::is_same<decltype(std::move(e).value()), std::string const&&>::value);
+  }
+
+  // value() rvalue throws with moved error
+  {
+    pf::expected<int, std::string> u(pf::unexpect, "rval-err");
+    bool caught = false;
+    try {
+      std::move(u).value();
+    } catch (pf::bad_expected_access<std::string> const& ex) {
+      caught = true;
+      CHECK(ex.error() == "rval-err");
+    }
+    CHECK(caught);
+  }
+
+  // error() rvalue overloads
+  {
+    pf::expected<int, std::string> e(pf::unexpect, "err");
+    STATIC_REQUIRE(std::is_same<decltype(std::move(e).error()), std::string&&>::value);
+    std::string s = std::move(e).error();
+    CHECK(s == "err");
+  }
+  {
+    pf::expected<int, std::string> const e(pf::unexpect, "cerr");
+    STATIC_REQUIRE(std::is_same<decltype(std::move(e).error()), std::string const&&>::value);
+  }
+
+  // operator* rvalue overloads
+  {
+    pf::expected<std::string, int> e(pf::in_place, "deref");
+    STATIC_REQUIRE(std::is_same<decltype(*std::move(e)), std::string&&>::value);
+    std::string s = *std::move(e);
+    CHECK(s == "deref");
+  }
+  {
+    pf::expected<std::string, int> const e(pf::in_place, "cderef");
+    STATIC_REQUIRE(std::is_same<decltype(*std::move(e)), std::string const&&>::value);
+  }
+}
+
+TEST_CASE("expected<void> rvalue observers")
+{
+  // value() rvalue on void (just must not throw)
+  {
+    pf::expected<void, int> e;
+    std::move(e).value();
+  }
+
+  // value() rvalue throws with moved error
+  {
+    pf::expected<void, std::string> u(pf::unexpect, "void-rval");
+    bool caught = false;
+    try {
+      std::move(u).value();
+    } catch (pf::bad_expected_access<std::string> const& ex) {
+      caught = true;
+      CHECK(ex.error() == "void-rval");
+    }
+    CHECK(caught);
+  }
+
+  // error() rvalue overloads
+  {
+    pf::expected<void, std::string> e(pf::unexpect, "verr");
+    STATIC_REQUIRE(std::is_same<decltype(std::move(e).error()), std::string&&>::value);
+    std::string s = std::move(e).error();
+    CHECK(s == "verr");
+  }
+  {
+    pf::expected<void, std::string> const e(pf::unexpect, "vcerr");
+    STATIC_REQUIRE(std::is_same<decltype(std::move(e).error()), std::string const&&>::value);
+  }
+}
+
+TEST_CASE("expected transform with function pointer")
+{
+  pf::expected<int, std::string> e(pf::in_place, 5);
+  auto r = e.transform(times_two);
+  CHECK(r.has_value());
+  CHECK(*r == 10);
+
+  pf::expected<int, std::string> u(pf::unexpect, "nope");
+  auto r2 = u.transform(times_two);
+  CHECK(!r2.has_value());
+  CHECK(r2.error() == "nope");
+}
+
+TEST_CASE("expected monadic rvalue overloads")
+{
+  // and_then on rvalue
+  {
+    pf::expected<std::string, int> e(pf::in_place, "hi");
+    auto r = std::move(e).and_then([](std::string&& s) { return pf::expected<std::size_t, int>(pf::in_place, s.size()); });
+    CHECK(r.has_value());
+    CHECK(*r == 2u);
+  }
+  // or_else on rvalue
+  {
+    pf::expected<int, std::string> u(pf::unexpect, "err");
+    auto r = std::move(u).or_else([](std::string&& s) { return pf::expected<int, std::string>(pf::in_place, static_cast<int>(s.size())); });
+    CHECK(r.has_value());
+    CHECK(*r == 3);
+  }
+  // transform on rvalue
+  {
+    pf::expected<std::string, int> e(pf::in_place, "test");
+    auto r = std::move(e).transform([](std::string&& s) { return s.size(); });
+    CHECK(r.has_value());
+    CHECK(*r == 4u);
+  }
+  // transform_error on rvalue
+  {
+    pf::expected<int, std::string> u(pf::unexpect, "boom");
+    auto r = std::move(u).transform_error([](std::string&& s) { return s.size(); });
+    CHECK(!r.has_value());
+    CHECK(r.error() == 4u);
+  }
+}

--- a/test/cxx11/expected.cpp
+++ b/test/cxx11/expected.cpp
@@ -576,6 +576,29 @@ TEST_CASE("expected value-forwarding ctor defaults U to remove_cv_t<T>")
   CHECK(InitCounter::copies == 0);
 }
 
+namespace {
+
+// copy ctor usable only from const lvalues; value()& must copy the error via as_const
+struct ConstOnlyCopy {
+  ConstOnlyCopy() = default;
+  ConstOnlyCopy(ConstOnlyCopy&) = delete;
+  ConstOnlyCopy(ConstOnlyCopy const&) = default;
+};
+
+}  // namespace
+
+TEST_CASE("expected value() throws bad_expected_access copied via as_const")
+{
+  pf::expected<int, ConstOnlyCopy> u(pf::unexpect);
+  bool caught = false;
+  try {
+    u.value();
+  } catch (pf::bad_expected_access<ConstOnlyCopy> const&) {
+    caught = true;
+  }
+  CHECK(caught);
+}
+
 TEST_CASE("expected converting construction with bool value type")
 {
   // [expected.object.cons] applies the converts-from-any-cvref check only "if T is not cv bool",

--- a/test/cxx14/CMakeLists.txt
+++ b/test/cxx14/CMakeLists.txt
@@ -7,6 +7,7 @@ target_sources(
         optional.cpp
         toptional.cpp
         variant.cpp
+        expected.cpp
 )
 
 set_target_properties(yk_polyfill_cxx14_test PROPERTIES CXX_EXTENSIONS OFF)

--- a/test/cxx14/expected.cpp
+++ b/test/cxx14/expected.cpp
@@ -1,0 +1,54 @@
+#if YK_POLYFILL_CATCH2_MAJOR_VERSION < 3
+#include <catch2/catch.hpp>
+#else
+#include <catch2/catch_test_macros.hpp>
+#endif
+
+#include <yk/polyfill/expected.hpp>
+#include <yk/polyfill/utility.hpp>
+
+#include <type_traits>
+
+namespace pf = yk::polyfill;
+
+TEST_CASE("expected constexpr C++14")
+{
+  // constexpr construction + observers (trivial arms)
+  {
+    constexpr pf::expected<int, int> e(pf::in_place, 5);
+    STATIC_REQUIRE(e.has_value());
+    STATIC_REQUIRE(static_cast<bool>(e));
+    STATIC_REQUIRE(*e == 5);
+    STATIC_REQUIRE(e.value() == 5);
+    STATIC_REQUIRE(e.value_or(0) == 5);
+    STATIC_REQUIRE(e.error_or(3) == 3);
+  }
+  {
+    constexpr pf::expected<int, int> u(pf::unexpect, 9);
+    STATIC_REQUIRE(!u.has_value());
+    STATIC_REQUIRE(u.error() == 9);
+    STATIC_REQUIRE(u.value_or(3) == 3);
+    STATIC_REQUIRE(u.error_or(0) == 9);
+  }
+
+  // constexpr comparisons
+  {
+    constexpr pf::expected<int, int> a(pf::in_place, 5);
+    constexpr pf::expected<int, int> b(pf::in_place, 5);
+    constexpr pf::expected<int, int> e(pf::unexpect, 1);
+    STATIC_REQUIRE(a == b);
+    STATIC_REQUIRE(a != e);
+    STATIC_REQUIRE(a == 5);
+    STATIC_REQUIRE(e == pf::unexpected<int>(1));
+  }
+
+  // constexpr void specialization
+  {
+    constexpr pf::expected<void, int> v;
+    STATIC_REQUIRE(v.has_value());
+    constexpr pf::expected<void, int> u(pf::unexpect, 4);
+    STATIC_REQUIRE(!u.has_value());
+    STATIC_REQUIRE(u.error() == 4);
+    STATIC_REQUIRE(v != u);
+  }
+}

--- a/test/cxx17/CMakeLists.txt
+++ b/test/cxx17/CMakeLists.txt
@@ -9,6 +9,7 @@ target_sources(
         toptional.cpp
         variant.cpp
         function_ref.cpp
+        expected.cpp
 )
 
 set_target_properties(yk_polyfill_cxx17_test PROPERTIES CXX_EXTENSIONS OFF)

--- a/test/cxx17/expected.cpp
+++ b/test/cxx17/expected.cpp
@@ -12,6 +12,33 @@
 
 namespace pf = yk::polyfill;
 
+namespace {
+
+// copy/move constructible + assignable, but with a potentially-throwing move constructor.
+struct ThrowMove {
+  ThrowMove() = default;
+  ThrowMove(ThrowMove const&) = default;
+  ThrowMove(ThrowMove&&) noexcept(false) {}
+  ThrowMove& operator=(ThrowMove const&) = default;
+  ThrowMove& operator=(ThrowMove&&) = default;
+};
+
+}  // namespace
+
+TEST_CASE("expected swap constraints observed through is_swappable")
+{
+  // std::swap is constrained on is_move_constructible && is_move_assignable only from C++17,
+  // so this is the earliest standard where is_swappable observes the
+  // [expected.object.swap] nothrow-move clause end to end.
+  STATIC_REQUIRE_FALSE(std::is_nothrow_move_constructible<ThrowMove>::value);
+  STATIC_REQUIRE_FALSE(pf::is_swappable<pf::expected<ThrowMove, ThrowMove>>::value);
+
+  // one nothrow-move-constructible arm restores swappability
+  STATIC_REQUIRE(pf::is_swappable<pf::expected<ThrowMove, int>>::value);
+  STATIC_REQUIRE(pf::is_swappable<pf::expected<int, std::string>>::value);
+  STATIC_REQUIRE(pf::is_swappable<pf::expected<void, int>>::value);
+}
+
 TEST_CASE("unexpected CTAD")
 {
   pf::unexpected u(5);

--- a/test/cxx17/expected.cpp
+++ b/test/cxx17/expected.cpp
@@ -1,0 +1,49 @@
+#if YK_POLYFILL_CATCH2_MAJOR_VERSION < 3
+#include <catch2/catch.hpp>
+#else
+#include <catch2/catch_test_macros.hpp>
+#endif
+
+#include <yk/polyfill/expected.hpp>
+#include <yk/polyfill/utility.hpp>
+
+#include <string>
+#include <type_traits>
+
+namespace pf = yk::polyfill;
+
+TEST_CASE("unexpected CTAD")
+{
+  pf::unexpected u(5);
+  STATIC_REQUIRE(std::is_same<decltype(u), pf::unexpected<int>>::value);
+  CHECK(u.error() == 5);
+
+  pf::unexpected s(std::string("boom"));
+  STATIC_REQUIRE(std::is_same<decltype(s), pf::unexpected<std::string>>::value);
+  CHECK(s.error() == "boom");
+}
+
+TEST_CASE("expected from CTAD-deduced unexpected")
+{
+  pf::expected<int, std::string> e = pf::unexpected(std::string("err"));
+  CHECK(!e.has_value());
+  CHECK(e.error() == "err");
+}
+
+TEST_CASE("expected constexpr C++17 monadic")
+{
+  constexpr pf::expected<int, int> e(pf::in_place, 4);
+
+  constexpr auto a = e.and_then([](int x) { return pf::expected<int, int>(pf::in_place, x * 2); });
+  STATIC_REQUIRE(a.has_value());
+  STATIC_REQUIRE(*a == 8);
+
+  constexpr pf::expected<int, int> u(pf::unexpect, 9);
+  constexpr auto o = u.or_else([](int x) { return pf::expected<int, int>(pf::in_place, x); });
+  STATIC_REQUIRE(o.has_value());
+  STATIC_REQUIRE(*o == 9);
+
+  constexpr auto te = u.transform_error([](int x) { return x + 1; });
+  STATIC_REQUIRE(!te.has_value());
+  STATIC_REQUIRE(te.error() == 10);
+}

--- a/test/cxx20/CMakeLists.txt
+++ b/test/cxx20/CMakeLists.txt
@@ -1,6 +1,6 @@
 add_executable(yk_polyfill_cxx20_test)
 
-target_sources(yk_polyfill_cxx20_test PRIVATE constant_wrapper.cpp function_ref.cpp unique_ptr.cpp optional.cpp toptional.cpp variant.cpp indirect.cpp polymorphic.cpp)
+target_sources(yk_polyfill_cxx20_test PRIVATE constant_wrapper.cpp function_ref.cpp unique_ptr.cpp optional.cpp toptional.cpp variant.cpp indirect.cpp polymorphic.cpp expected.cpp)
 
 set_target_properties(yk_polyfill_cxx20_test PROPERTIES CXX_EXTENSIONS OFF)
 

--- a/test/cxx20/expected.cpp
+++ b/test/cxx20/expected.cpp
@@ -1,0 +1,108 @@
+#if YK_POLYFILL_CATCH2_MAJOR_VERSION < 3
+#include <catch2/catch.hpp>
+#else
+#include <catch2/catch_test_macros.hpp>
+#endif
+
+#include <yk/polyfill/expected.hpp>
+#include <yk/polyfill/utility.hpp>
+
+#include <type_traits>
+
+namespace pf = yk::polyfill;
+
+namespace {
+
+// literal type with a non-trivial (constexpr) destructor, so expected uses the non-trivial
+// storage path and its member-changing operations are exercised in a constant expression.
+struct NonTrivial {
+  int value;
+  constexpr NonTrivial(int v = 0) noexcept : value(v) {}
+  constexpr NonTrivial(NonTrivial const&) = default;
+  constexpr NonTrivial(NonTrivial&&) = default;
+  constexpr NonTrivial& operator=(NonTrivial const&) = default;
+  constexpr NonTrivial& operator=(NonTrivial&&) = default;
+  constexpr ~NonTrivial() {}
+  constexpr bool operator==(NonTrivial const& other) const { return value == other.value; }
+};
+
+}  // namespace
+
+TEST_CASE("expected constexpr with non-trivial type (C++20)")
+{
+  STATIC_REQUIRE_FALSE(std::is_trivially_destructible<pf::expected<NonTrivial, int>>::value);
+
+  constexpr auto construct = []() {
+    pf::expected<NonTrivial, int> e(pf::in_place, 5);
+    return e.has_value() && e->value == 5;
+  };
+  STATIC_REQUIRE(construct());
+
+  constexpr auto assign_arm_switch = []() {
+    pf::expected<NonTrivial, int> e(pf::in_place, 1);
+    e = pf::unexpected<int>(9);  // value -> error (reinit)
+    bool ok1 = !e.has_value() && e.error() == 9;
+    e = NonTrivial(2);  // error -> value (reinit)
+    bool ok2 = e.has_value() && e->value == 2;
+    return ok1 && ok2;
+  };
+  STATIC_REQUIRE(assign_arm_switch());
+
+  constexpr auto emplace = []() {
+    pf::expected<NonTrivial, int> e(pf::unexpect, 1);
+    e.emplace(7);
+    return e.has_value() && e->value == 7;
+  };
+  STATIC_REQUIRE(emplace());
+
+  constexpr auto do_swap = []() {
+    pf::expected<NonTrivial, int> a(pf::in_place, 1);
+    pf::expected<NonTrivial, int> b(pf::unexpect, 2);
+    a.swap(b);
+    return !a.has_value() && a.error() == 2 && b.has_value() && b->value == 1;
+  };
+  STATIC_REQUIRE(do_swap());
+
+  constexpr auto void_reinit = []() {
+    pf::expected<void, NonTrivial> e;
+    e = pf::unexpected<NonTrivial>(NonTrivial(3));  // value -> error
+    bool ok1 = !e.has_value() && e.error().value == 3;
+    e.emplace();  // error -> value
+    return ok1 && e.has_value();
+  };
+  STATIC_REQUIRE(void_reinit());
+}
+
+TEST_CASE("expected != is synthesized from == (C++20)")
+{
+  pf::expected<int, int> a(pf::in_place, 1);
+  pf::expected<int, int> b(pf::in_place, 2);
+  pf::expected<int, int> e(pf::unexpect, 5);
+
+  CHECK(a != b);
+  CHECK(!(a != pf::expected<int, int>(pf::in_place, 1)));
+  CHECK(a != e);
+
+  // reversed / rewritten candidates
+  CHECK(a != 2);
+  CHECK(2 != a);
+  CHECK(a == 1);
+  CHECK(1 == a);
+  CHECK(e != pf::unexpected<int>(4));
+  CHECK(pf::unexpected<int>(4) != e);
+  CHECK(e == pf::unexpected<int>(5));
+
+  pf::expected<void, int> v;
+  pf::expected<void, int> w(pf::unexpect, 1);
+  CHECK(v != w);
+  CHECK(!(v != pf::expected<void, int>()));
+}
+
+TEST_CASE("expected constexpr comparisons (C++20)")
+{
+  constexpr pf::expected<int, int> a(pf::in_place, 1);
+  constexpr pf::expected<int, int> b(pf::unexpect, 2);
+  STATIC_REQUIRE(a != b);
+  STATIC_REQUIRE(a == 1);
+  STATIC_REQUIRE(b == pf::unexpected<int>(2));
+}


### PR DESCRIPTION
Resolves #26.

Implements a C++11-compatible polyfill of `std::expected<T, E>` (P0323).

## Surface
- `expected<T, E>` and the `expected<void, E>` specialization
- `unexpected<E>` (converting / `in_place` / init-list ctors, `error()`×4, `swap`, `operator==`, deduction guide)
- `bad_expected_access<void>` : `std::exception`; `bad_expected_access<E>` (stores `E`, `error()`×4)
- `unexpect_t` / `unexpect`
- Monadic `and_then` / `or_else` / `transform` / `transform_error` (4 ref-qual overloads each; void-value variants call the callable with no argument)
- `value_or` (non-void) / `error_or`; member and free `swap`
- Comparisons: `operator==` always; `operator!=` below C++20 (C++20+ rewrites from `==`)

Standard reference `T`/`E` are rejected via `static_assert`, matching `std::expected`.

## Design notes
- Storage layers over `detail::cond_trivial_smf` (as `optional`/`variant` do) with both arms in the triviality pack, plus an `expected_assign_guard` base for the extra `[expected.object.assign]` nothrow-move deletion that `cond_trivial_smf` can't express.
- A union with a transient `valueless` state keeps `cond_trivial_smf`'s default-then-fill contract satisfied while the type is never *observably* valueless.
- Arm-switching assignment uses the standard's `reinit-expected` three-rung strategy (nothrow-construct / temp-then-move / backup-then-restore) for the strong exception guarantee; the third rung's `try`/`catch` is gated to C++20 `constexpr`.
- Feature-gated via `YK_POLYFILL_CXX*_CONSTEXPR` / `YK_POLYFILL_NODISCARD`; no `<compare>` (there is no `operator<=>`).

## Tests
`test/cxx{11,14,17,20}/expected.cpp` (cxx11 is the comprehensive bulk; higher standards add constexpr depth, CTAD, and `!=`-rewrite checks), including dedicated cases for the reinit strong guarantee and the assign-SMF deletion.

## Verification
Built and ran locally with **g++-14** and **clang++-21** across **C++11/14/17/20** (real Catch2 v2 for C++11, v3 for C++14+); full C++11 suite and the `expected` cases pass on every combination. MSVC not exercised locally — relies on CI.
